### PR TITLE
Chords: control midi note output with keyboard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ That basic sequencer runs as one module in Hachi.
 
 Tracking bugs, needed improvements, and all-new features using [issues](https://github.com/perkowitz/issho/issues) 
 here in Github, but also via [HuBoard](https://huboard.com/perkowitz/issho#/milestones). 
+
+# Release notes
+
+## 2017-01-29: v1.0.1
+
+- Add configurable keyboard device
+- Added Chords, ChordReceiver, ChordModule to track chords from keyboard device and apply chords to outgoing MIDI notes
+- Updated MonoModule and StepModule to extend ChordModule so they follow chords
+- Added chord options to keyboard configuration
+- Updated doc to cover chords and keyboard configuration
+- Added tests for Chords

--- a/doc/hachi/hachi.md
+++ b/doc/hachi/hachi.md
@@ -84,6 +84,49 @@ Launchpad's MIDI out port. For example, I have my NanoKontrol programmed to cont
 Mutable Shruthi. While using Hachi to sequence the Shruthi, I can plug the NanoKontrol into the Pi and use
 it to tweak the Shruthi's sounds.
 
+### Knobby Configuration
+
+A "knobby" device can be added for sending MIDI controllers to downstream MIDI modules. Adding the device to the config will tell
+Hachi to route the controller's output to the Launchpad Pro's MIDI out, so that control messages can be sent to any devices
+on the MIDI chain. The controller must be set up to send the desired messages; Hachi will not remap the MIDI messages in any way.
+
+```
+  "devices": {
+    "knobby": {
+      "names":[
+        "nanokontrol"
+      ]
+    }
+  }
+```
+
+### Keyboard Configuration
+
+A MIDI keyboard device can be added to Hachi. Hachi will route MIDI from the keyboard into a ChordReceiver object, which monitors the currently played
+notes to maintain the current chord. This chord is passed on to modules like MonoModule and StepModule, which can remap their MIDI notes to use 
+only notes in the specified chord. In other words, playing a chord on the connected keyboard will cause Hachi's sequencers to play their sequences
+in that key. 
+
+The ChordReceiver may have hold enabled or disabled. When disabled, the chord will be maintained only as long as the keys are held down.
+When a key is released, it is removed from the chord, and when all keys are released the chord is cleared. With hold enabled, as long as 
+a note is held down, additional notes played will be added to the current chord. When all notes are released, the current chord will be 
+held. The chord will be cleared when the ChordReceiver receives a MIDI controller message (any value) for the 
+holdClearControllerNumber (defaults to 64, hold). Hold can be enabled or disabled in the configuration with "chordHoldEnabled" set to
+true or false. The hold clear controller number can also be specified. For example, if your MIDI keyboard has a mod wheel but no hold controller,
+set the controller number to 1 to use the mod wheel to clear hold.
+
+
+```
+  "devices": {
+    "keyboard": {
+      "names":[
+        "LPK25"
+      ],
+      "chordHoldEnabled": false,
+      "holdClearControllerNumber": 64
+    }
+  }
+```
 
 ## Module Configuration
 

--- a/doc/hachi/modules/mono.md
+++ b/doc/hachi/modules/mono.md
@@ -110,6 +110,11 @@ set to use a fuchsia or orange color palette.
   ]
 ```
 
+## Keyboard and Chords
+
+If Hachi is configured with a MIDI keyboard (see [the main Hachi manual](../hachi.md)), MonoModule will respond to 
+chords by filtering output MIDI notes to the closest Chord note.
+
 # Color Palette
 
 Mono has two defined palettes: fuchsia and orange. This section describes the color values in the fuchsia palette.

--- a/doc/hachi/modules/step.md
+++ b/doc/hachi/modules/step.md
@@ -121,6 +121,11 @@ to specify filenames for saving data.
   ]
 ```
 
+## Keyboard and Chords
+
+If Hachi is configured with a MIDI keyboard (see [the main Hachi manual](../hachi.md)), MonoModule will respond to 
+chords by filtering output MIDI notes to the closest Chord note.
+
 # Color Palette
 
 Step has only one defined palette. 

--- a/doc/hachi/modules/step.md
+++ b/doc/hachi/modules/step.md
@@ -123,7 +123,7 @@ to specify filenames for saving data.
 
 ## Keyboard and Chords
 
-If Hachi is configured with a MIDI keyboard (see [the main Hachi manual](../hachi.md)), MonoModule will respond to 
+If Hachi is configured with a MIDI keyboard (see [the main Hachi manual](../hachi.md)), StepModule will respond to 
 chords by filtering output MIDI notes to the closest Chord note.
 
 # Color Palette

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.perkowitz</groupId>
     <artifactId>issho</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <name>Issho</name>
 
 

--- a/src/main/java/net/perkowitz/issho/devices/Keyboard.java
+++ b/src/main/java/net/perkowitz/issho/devices/Keyboard.java
@@ -44,7 +44,12 @@ public class Keyboard implements Receiver {
 //                        System.out.printf("Keyboard NOTE OFF: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
                         outputReceiver.send(message, timeStamp);
                         break;
+                    case CONTROL_CHANGE:
+//                        System.out.printf("Keyboard MIDI CC: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
+                        outputReceiver.send(message, timeStamp);
+                        break;
                     default:
+
                 }
             }
         }

--- a/src/main/java/net/perkowitz/issho/devices/Keyboard.java
+++ b/src/main/java/net/perkowitz/issho/devices/Keyboard.java
@@ -5,7 +5,6 @@ import javax.sound.midi.*;
 import java.util.List;
 
 import static javax.sound.midi.ShortMessage.*;
-import static javax.sound.midi.ShortMessage.CONTROL_CHANGE;
 import static javax.sound.midi.ShortMessage.NOTE_OFF;
 
 /**

--- a/src/main/java/net/perkowitz/issho/devices/Keyboard.java
+++ b/src/main/java/net/perkowitz/issho/devices/Keyboard.java
@@ -1,0 +1,82 @@
+package net.perkowitz.issho.devices;
+
+import net.perkowitz.issho.util.MidiUtil;
+import javax.sound.midi.*;
+import java.util.List;
+
+import static javax.sound.midi.ShortMessage.*;
+import static javax.sound.midi.ShortMessage.CONTROL_CHANGE;
+import static javax.sound.midi.ShortMessage.NOTE_OFF;
+
+/**
+ * Created by optic on 1/14/17.
+ */
+public class Keyboard implements Receiver {
+
+    private static int MIDI_REALTIME_COMMAND = 0xF0;
+
+    private Transmitter inputTransmitter;
+    private Receiver outputReceiver;
+
+    public Keyboard(Transmitter inputTransmitter, Receiver outputReceiver) {
+        this.inputTransmitter = inputTransmitter;
+        this.inputTransmitter.setReceiver(this);
+        this.outputReceiver = outputReceiver;
+    }
+
+
+
+    /***** midi receiver implementation **************************************************************/
+
+    public void send(MidiMessage message, long timeStamp) {
+
+        if (message instanceof ShortMessage) {
+            ShortMessage shortMessage = (ShortMessage) message;
+            int command = shortMessage.getCommand();
+            int status = shortMessage.getStatus();
+
+            if (command != MIDI_REALTIME_COMMAND) {
+                switch (command) {
+                    case NOTE_ON:
+//                        System.out.printf("Keyboard NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
+                        outputReceiver.send(message, timeStamp);
+                        break;
+                    case NOTE_OFF:
+//                        System.out.printf("Keyboard NOTE OFF: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
+                        outputReceiver.send(message, timeStamp);
+                        break;
+                    default:
+                }
+            }
+        }
+    }
+
+    public void close() {
+
+    }
+
+
+    /***** static methods **********************************************/
+
+    public static Keyboard fromMidiDevice(List<String> names, Receiver targetReceiver) {
+
+        MidiDevice midiInput = MidiUtil.findMidiDevice(names.toArray(new String[0]), false, true);
+        if (midiInput == null) {
+            System.out.printf("Unable to find keyboard device matching name: %s\n", names);
+            return null;
+        }
+
+        try {
+            midiInput.open();
+            Keyboard keyboard = new Keyboard(midiInput.getTransmitter(), targetReceiver);
+            return keyboard;
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        return null;
+    }
+
+
+}

--- a/src/main/java/net/perkowitz/issho/hachi/Chord.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Chord.java
@@ -30,7 +30,7 @@ public class Chord {
     }
 
     @Setter private TransposeMode transposeMode = NO_TRANSPOSE;
-    @Setter private NoteMapMode noteMapMode = ROUND_ROBIN;
+    @Setter private NoteMapMode noteMapMode = NEAREST;
     @Getter private List<Integer> baseNotes;
     private List<Integer> notes;
     @Getter private int transpose = 0;

--- a/src/main/java/net/perkowitz/issho/hachi/Chord.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Chord.java
@@ -31,7 +31,7 @@ public class Chord {
 
     @Setter private TransposeMode transposeMode = NO_TRANSPOSE;
     @Setter private NoteMapMode noteMapMode = ROUND_ROBIN;
-    private List<Integer> baseNotes;
+    @Getter private List<Integer> baseNotes;
     private List<Integer> notes;
     @Getter private int transpose = 0;
     private Integer[] noteMap = new Integer[12];

--- a/src/main/java/net/perkowitz/issho/hachi/Chord.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Chord.java
@@ -1,0 +1,256 @@
+package net.perkowitz.issho.hachi;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static net.perkowitz.issho.hachi.Chord.NoteMapMode.FLOOR;
+import static net.perkowitz.issho.hachi.Chord.NoteMapMode.NEAREST;
+import static net.perkowitz.issho.hachi.Chord.NoteMapMode.ROUND_ROBIN;
+import static net.perkowitz.issho.hachi.Chord.TransposeMode.LOWEST_NOTE;
+import static net.perkowitz.issho.hachi.Chord.TransposeMode.NO_TRANSPOSE;
+
+/**
+ * Created by optic on 1/14/17.
+ */
+public class Chord {
+
+    public enum TransposeMode {
+        NO_TRANSPOSE, LOWEST_NOTE, LOWEST_BASE_NOTE, FIRST_NOTE
+    }
+
+    public enum NoteMapMode {
+        NO_MAP, NEAREST, FLOOR, ROUND_ROBIN
+    }
+
+    @Setter private TransposeMode transposeMode = NO_TRANSPOSE;
+    @Setter private NoteMapMode noteMapMode = ROUND_ROBIN;
+    private List<Integer> baseNotes;
+    private List<Integer> notes;
+    @Getter private int transpose = 0;
+    private Integer[] noteMap = new Integer[12];
+
+
+
+    public Chord() {
+        this.notes = Lists.newArrayList();
+        this.baseNotes = Lists.newArrayList();
+        computeTranspose();
+        computeNoteMap();
+    }
+
+    public Chord(List<Integer> baseNotes) {
+        this.notes = baseNotes;
+        this.baseNotes = baseNotes;
+        computeTranspose();
+        computeNoteMap();
+    }
+
+
+    /***** list management *****************************/
+
+    public void add(Integer note) {
+        Integer baseNote = note % 12;
+        if (!baseNotes.contains(baseNote)) {
+            baseNotes.add(baseNote);
+            computeTranspose();
+            computeNoteMap();
+        }
+//        System.out.printf("Chord: add %d, transpose=%d, map=%s\n", note, transpose, Arrays.toString(noteMap));
+    }
+
+    public void remove(Integer note) {
+        Integer baseNote = note % 12;
+        baseNotes.remove(baseNote);
+        computeTranspose();
+        computeNoteMap();
+
+//        System.out.printf("Chord: remove %d, transpose=%d, map=%s\n", note, transpose, Arrays.toString(noteMap));
+    }
+
+    public void clear() {
+        baseNotes.clear();
+    }
+
+    public boolean isEmpty() {
+        return baseNotes.isEmpty();
+    }
+
+
+    /***** private implementation **********************************/
+
+    private void computeTranspose() {
+
+        switch (transposeMode) {
+            case NO_TRANSPOSE:
+                transpose = 0;
+                break;
+
+            case LOWEST_NOTE:
+                Integer t = null;
+                for (Integer note : notes) {
+                    if (t == null || note < t) {
+                        t = note;
+                    }
+                }
+                if (t == null) {
+                    transpose = 0;
+                } else {
+                    transpose = t % 12;
+                }
+                break;
+
+            case LOWEST_BASE_NOTE:
+                t = null;
+                for (Integer note : notes) {
+                    int baseNote = note % 12;
+                    if (t == null || baseNote < t) {
+                        t = baseNote;
+                    }
+                }
+                if (t == null) {
+                    transpose = 0;
+                } else {
+                    transpose = t % 12;
+                }
+                break;
+
+            case FIRST_NOTE:
+                if (baseNotes.isEmpty()) {
+                    transpose = 0;
+                } else {
+                    transpose = baseNotes.get(0) % 12;
+                }
+                break;
+
+            default:
+                transpose = 0;
+                break;
+
+        }
+    }
+
+    private void computeNoteMap() {
+
+        if (isEmpty()) {
+            for (int i = 0; i < 12; i++) {
+                noteMap[i] = i;
+            }
+            return;
+        }
+
+        switch (noteMapMode) {
+            case NEAREST:
+                noteMap = nearestNoteMap();
+                break;
+            case FLOOR:
+                noteMap = floorNoteMap();
+                break;
+            case ROUND_ROBIN:
+                noteMap = roundRobinNoteMap();
+                break;
+            case NO_MAP:
+            default:
+                break;
+        }
+
+    }
+
+    public int mapNote(int note) {
+        int octave = note / 12;
+        int baseNote = note % 12;
+        int mappedBaseNote = noteMap[baseNote];
+        return (octave * 12) + mappedBaseNote;
+    }
+
+    /***** note map types **********************************/
+
+    private Integer[] nearestNoteMap() {
+        Integer[] baseNoteMap = new Integer[12];
+        for (int baseNote : baseNotes) {
+            baseNoteMap[baseNote] = baseNote;
+        }
+
+        Integer[] newNoteMap = new Integer[12];
+        for (int n = 0; n < 12; n++) {
+            int left = n;
+            int right = (n + 1) % 12;
+            while (baseNoteMap[left] == null && baseNoteMap[right] == null && right != n) {
+                left = (left - 1 + 12) % 12;
+                right = (right + 1) % 12;
+            }
+            if (baseNoteMap[left] != null) {
+                newNoteMap[n] = baseNoteMap[left];
+            } else if (baseNoteMap[right] != null) {
+                newNoteMap[n] = baseNoteMap[right];
+            } else {
+                newNoteMap[n] = n;
+            }
+        }
+
+        return newNoteMap;
+    }
+
+    private Integer[] floorNoteMap() {
+        Integer[] newNoteMap = new Integer[12];
+        for (int baseNote : baseNotes) {
+            newNoteMap[baseNote] = baseNote;
+        }
+
+        for (int n = 0; n < 12; n++) {
+            if (newNoteMap[n] == null) {
+                int left = (n - 1 + 12) % 12;
+                while (newNoteMap[left] == null && left != n) {
+                    left = (left - 1 + 12) % 12;
+                }
+                if (newNoteMap[left] != null) {
+                    newNoteMap[n] = newNoteMap[left];
+                } else {
+                    newNoteMap[n] = n;
+                }
+            }
+        }
+
+        return newNoteMap;
+    }
+
+    private Integer[] roundRobinNoteMap() {
+        Integer[] newNoteMap = new Integer[12];
+        for (int n = 0; n < 12; n++) {
+            newNoteMap[n] = baseNotes.get(n % baseNotes.size());
+        }
+        return newNoteMap;
+    }
+
+
+    /***** overrides **********************************/
+
+    @Override
+    public String toString() {
+        return "Chord:" + baseNotes.toString();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof Chord) {
+            Chord chord = (Chord)object;
+            return this.baseNotes.equals(chord.baseNotes);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+
+
+
+}

--- a/src/main/java/net/perkowitz/issho/hachi/Chord.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Chord.java
@@ -56,6 +56,7 @@ public class Chord {
     /***** list management *****************************/
 
     public void add(Integer note) {
+        if (note == null || note < 0) return;
         Integer baseNote = note % 12;
         if (!baseNotes.contains(baseNote)) {
             baseNotes.add(baseNote);
@@ -76,10 +77,16 @@ public class Chord {
 
     public void clear() {
         baseNotes.clear();
+        computeTranspose();
+        computeNoteMap();
     }
 
     public boolean isEmpty() {
         return baseNotes.isEmpty();
+    }
+
+    public int size() {
+        return baseNotes.size();
     }
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
+++ b/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
@@ -13,8 +13,6 @@ import java.util.Set;
 import static javax.sound.midi.ShortMessage.CONTROL_CHANGE;
 import static javax.sound.midi.ShortMessage.NOTE_OFF;
 import static javax.sound.midi.ShortMessage.NOTE_ON;
-import static net.perkowitz.issho.hachi.ChordReceiver.SustainToggleMode.HIGH_TOGGLE;
-import static net.perkowitz.issho.hachi.ChordReceiver.SustainToggleMode.NORMAL;
 
 /**
  * Created by optic on 1/14/17.
@@ -30,7 +28,7 @@ public class ChordReceiver implements Receiver {
     private List<Chordable> chordables;
     private Chord chord;
     private Set<Integer> currentlyHeldNotes = Sets.newHashSet();
-    private boolean chordHold = true;
+    @Setter private boolean chordHold = true;
     private int sustainControllerNumber = 64;
 
 
@@ -63,7 +61,9 @@ public class ChordReceiver implements Receiver {
                         int note = shortMessage.getData1();
 //                        System.out.printf("ChordReceiver NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), note, shortMessage.getData2());
                         if (shortMessage.getData2() == 0) {
-                            //chord.remove(note);  // we don't remove until all notes are lifted
+                            if (!chordHold) {
+                                chord.remove(note);
+                            }
                             currentlyHeldNotes.remove(note);
                         } else {
                             // as long as you hold down notes, you can add more to the chord; when you release all, next play will start a new chord
@@ -78,7 +78,9 @@ public class ChordReceiver implements Receiver {
                     case NOTE_OFF:
 //                        System.out.printf("ChordReceiver NOTE OFF: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
                         note = shortMessage.getData1();
-                        //chord.remove(note);  // we don't remove until all notes are lifted
+                        if (!chordHold) {
+                            chord.remove(note);
+                        }
                         currentlyHeldNotes.remove(note);
                         sendChord();
                         break;
@@ -88,6 +90,7 @@ public class ChordReceiver implements Receiver {
                         if (controllerNumber == sustainControllerNumber) {
                             chord.clear();
                         }
+                        sendChord();
                         break;
                     default:
                 }

--- a/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
+++ b/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
@@ -29,7 +29,7 @@ public class ChordReceiver implements Receiver {
     private Chord chord;
     private Set<Integer> currentlyHeldNotes = Sets.newHashSet();
     @Setter private boolean chordHold = true;
-    private int sustainControllerNumber = 64;
+    @Setter private int holdClearControllerNumber = 64;
 
 
 
@@ -87,7 +87,7 @@ public class ChordReceiver implements Receiver {
                     case CONTROL_CHANGE:
 //                        System.out.printf("ChordReceiver MIDI CC: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
                         int controllerNumber = shortMessage.getData1();
-                        if (controllerNumber == sustainControllerNumber) {
+                        if (controllerNumber == holdClearControllerNumber) {
                             chord.clear();
                         }
                         sendChord();

--- a/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
+++ b/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
@@ -1,23 +1,37 @@
 package net.perkowitz.issho.hachi;
 
+import com.google.common.collect.Sets;
+import lombok.Setter;
+
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.Receiver;
 import javax.sound.midi.ShortMessage;
 
 import java.util.List;
+import java.util.Set;
 
+import static javax.sound.midi.ShortMessage.CONTROL_CHANGE;
 import static javax.sound.midi.ShortMessage.NOTE_OFF;
 import static javax.sound.midi.ShortMessage.NOTE_ON;
+import static net.perkowitz.issho.hachi.ChordReceiver.SustainToggleMode.HIGH_TOGGLE;
+import static net.perkowitz.issho.hachi.ChordReceiver.SustainToggleMode.NORMAL;
 
 /**
  * Created by optic on 1/14/17.
  */
 public class ChordReceiver implements Receiver {
 
+    public enum SustainToggleMode {
+        NORMAL, HIGH_TOGGLE
+    }
+
     private static int MIDI_REALTIME_COMMAND = 0xF0;
 
     private List<Chordable> chordables;
     private Chord chord;
+    private Set<Integer> currentlyHeldNotes = Sets.newHashSet();
+    private boolean chordHold = true;
+    private int sustainControllerNumber = 64;
 
 
 
@@ -28,6 +42,7 @@ public class ChordReceiver implements Receiver {
 
 
     private void sendChord() {
+        System.out.printf("Chord: %s\n", chord);
         for (Chordable chordable : chordables) {
             chordable.setChord(chord);
         }
@@ -48,17 +63,31 @@ public class ChordReceiver implements Receiver {
                         int note = shortMessage.getData1();
 //                        System.out.printf("ChordReceiver NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), note, shortMessage.getData2());
                         if (shortMessage.getData2() == 0) {
-                            chord.remove(note);
+                            //chord.remove(note);  // we don't remove until all notes are lifted
+                            currentlyHeldNotes.remove(note);
                         } else {
+                            // as long as you hold down notes, you can add more to the chord; when you release all, next play will start a new chord
+                            if (currentlyHeldNotes.isEmpty()) {
+                                chord.clear();
+                            }
                             chord.add(note);
+                            currentlyHeldNotes.add(note);
                         }
                         sendChord();
                         break;
                     case NOTE_OFF:
 //                        System.out.printf("ChordReceiver NOTE OFF: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
                         note = shortMessage.getData1();
-                        chord.remove(note);
+                        //chord.remove(note);  // we don't remove until all notes are lifted
+                        currentlyHeldNotes.remove(note);
                         sendChord();
+                        break;
+                    case CONTROL_CHANGE:
+//                        System.out.printf("ChordReceiver MIDI CC: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
+                        int controllerNumber = shortMessage.getData1();
+                        if (controllerNumber == sustainControllerNumber) {
+                            chord.clear();
+                        }
                         break;
                     default:
                 }

--- a/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
+++ b/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
@@ -42,7 +42,7 @@ public class ChordReceiver implements Receiver {
 
 
     private void sendChord() {
-        System.out.printf("Chord: %s\n", chord);
+//        System.out.printf("Chord: %s\n", chord);
         for (Chordable chordable : chordables) {
             chordable.setChord(chord);
         }

--- a/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
+++ b/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
@@ -1,0 +1,75 @@
+package net.perkowitz.issho.hachi;
+
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.ShortMessage;
+
+import java.util.List;
+
+import static javax.sound.midi.ShortMessage.NOTE_OFF;
+import static javax.sound.midi.ShortMessage.NOTE_ON;
+
+/**
+ * Created by optic on 1/14/17.
+ */
+public class ChordReceiver implements Receiver {
+
+    private static int MIDI_REALTIME_COMMAND = 0xF0;
+
+    private List<Chordable> chordables;
+    private Chord chord;
+
+
+
+    public ChordReceiver(List<Chordable> chordables) {
+        this.chordables = chordables;
+        this.chord = new Chord();
+    }
+
+
+    private void sendChord() {
+        for (Chordable chordable : chordables) {
+            chordable.setChord(chord);
+        }
+    }
+
+
+    /***** midi receiver implementation **************************************************************/
+
+    public void send(MidiMessage message, long timeStamp) {
+
+        if (message instanceof ShortMessage) {
+            ShortMessage shortMessage = (ShortMessage) message;
+            int command = shortMessage.getCommand();
+
+            if (command != MIDI_REALTIME_COMMAND) {
+                switch (command) {
+                    case NOTE_ON:
+                        int note = shortMessage.getData1();
+//                        System.out.printf("ChordReceiver NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), note, shortMessage.getData2());
+                        if (shortMessage.getData2() != 0) {
+                            chord.add(note);
+                            System.out.println(chord);
+                            sendChord();
+                        }
+                        break;
+                    case NOTE_OFF:
+//                        System.out.printf("ChordReceiver NOTE OFF: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
+                        note = shortMessage.getData1();
+                        chord.remove(note);
+                        System.out.println(chord);
+                        sendChord();
+                        break;
+                    default:
+                }
+            }
+        }
+    }
+
+    public void close() {
+
+    }
+
+
+
+}

--- a/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
+++ b/src/main/java/net/perkowitz/issho/hachi/ChordReceiver.java
@@ -47,17 +47,17 @@ public class ChordReceiver implements Receiver {
                     case NOTE_ON:
                         int note = shortMessage.getData1();
 //                        System.out.printf("ChordReceiver NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), note, shortMessage.getData2());
-                        if (shortMessage.getData2() != 0) {
+                        if (shortMessage.getData2() == 0) {
+                            chord.remove(note);
+                        } else {
                             chord.add(note);
-                            System.out.println(chord);
-                            sendChord();
                         }
+                        sendChord();
                         break;
                     case NOTE_OFF:
 //                        System.out.printf("ChordReceiver NOTE OFF: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
                         note = shortMessage.getData1();
                         chord.remove(note);
-                        System.out.println(chord);
                         sendChord();
                         break;
                     default:

--- a/src/main/java/net/perkowitz/issho/hachi/Chordable.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Chordable.java
@@ -10,6 +10,6 @@ import java.util.List;
  */
 public interface Chordable extends Module {
 
-    public void setChordNotes(List<Integer> notes);
+    public void setChord(Chord chord);
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/Hachi.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Hachi.java
@@ -2,6 +2,7 @@ package net.perkowitz.issho.hachi;
 
 import com.google.common.collect.Lists;
 import net.perkowitz.issho.devices.GridDisplay;
+import net.perkowitz.issho.devices.Keyboard;
 import net.perkowitz.issho.devices.launchpadpro.*;
 import net.perkowitz.issho.hachi.modules.*;
 import net.perkowitz.issho.hachi.modules.example.ExampleModule;
@@ -49,6 +50,8 @@ public class Hachi {
     private static MidiDevice knobInput;
     private static MidiDevice knobOutput;
 
+    private static Keyboard keyboard = null;
+
     private static HachiController controller;
     private static CountDownLatch stop = new CountDownLatch(1);
 
@@ -78,6 +81,10 @@ public class Hachi {
             settings = SettingsUtil.getSettings(settingsFile);
         }
 
+        Map<Object,Object> deviceConfigs = (Map<Object,Object>)settings.get("devices");
+
+
+
         LaunchpadPro launchpadPro = getLaunchpad();
         GridDisplay gridDisplay = launchpadPro;
 
@@ -100,6 +107,16 @@ public class Hachi {
 
         // make the HachiController receive external midi
         midiInput.getTransmitter().setReceiver(controller);
+
+        if (deviceConfigs != null) {
+            if (deviceConfigs.get("keyboard") != null) {
+                List<String> names = (List<String>)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("names");
+                System.out.printf("Looking for keyboard: %s...\n", names);
+                keyboard = Keyboard.fromMidiDevice(names, controller.getChordReceiver());
+            }
+        }
+
+
 
         System.out.printf("Running controller...\n");
         controller.run();

--- a/src/main/java/net/perkowitz/issho/hachi/Hachi.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Hachi.java
@@ -111,11 +111,17 @@ public class Hachi {
         if (deviceConfigs != null) {
             if (deviceConfigs.get("keyboard") != null) {
                 List<String> names = (List<String>)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("names");
-                Integer holdClearControllerNumber = (Integer)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("holdClearControllerNumber");
                 System.out.printf("Looking for keyboard: %s...\n", names);
                 keyboard = Keyboard.fromMidiDevice(names, controller.getChordReceiver());
+
+                Integer holdClearControllerNumber = (Integer)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("holdClearControllerNumber");
                 if (holdClearControllerNumber != null) {
                     controller.getChordReceiver().setHoldClearControllerNumber(holdClearControllerNumber);
+                }
+
+                Boolean chordHoldEnabled = (Boolean)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("chordHoldEnabled");
+                if (chordHoldEnabled != null) {
+                    controller.getChordReceiver().setChordHold(chordHoldEnabled);
                 }
             }
         }

--- a/src/main/java/net/perkowitz/issho/hachi/Hachi.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Hachi.java
@@ -111,12 +111,14 @@ public class Hachi {
         if (deviceConfigs != null) {
             if (deviceConfigs.get("keyboard") != null) {
                 List<String> names = (List<String>)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("names");
+                Integer holdClearControllerNumber = (Integer)((Map<Object,Object>)deviceConfigs.get("keyboard")).get("holdClearControllerNumber");
                 System.out.printf("Looking for keyboard: %s...\n", names);
                 keyboard = Keyboard.fromMidiDevice(names, controller.getChordReceiver());
+                if (holdClearControllerNumber != null) {
+                    controller.getChordReceiver().setHoldClearControllerNumber(holdClearControllerNumber);
+                }
             }
         }
-
-
 
         System.out.printf("Running controller...\n");
         controller.run();

--- a/src/main/java/net/perkowitz/issho/hachi/HachiController.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiController.java
@@ -1,6 +1,7 @@
 package net.perkowitz.issho.hachi;
 
 import com.google.common.collect.Lists;
+import lombok.Getter;
 import lombok.Setter;
 import net.perkowitz.issho.devices.*;
 import net.perkowitz.issho.devices.launchpadpro.Color;
@@ -42,9 +43,12 @@ public class HachiController implements GridListener, Clockable, Receiver {
     private GridListener activeListener = null;
     private GridDisplay display;
     private ModuleDisplay[] displays;
+
     private List<Clockable> clockables = Lists.newArrayList();
     private List<Triggerable> triggerables = Lists.newArrayList();
+    private List<Chordable> chordables = Lists.newArrayList();
     private ShihaiModule shihaiModule = null;
+    @Getter private ChordReceiver chordReceiver;
 
     private static CountDownLatch stop = new CountDownLatch(1);
     private static Timer timer = null;
@@ -78,10 +82,16 @@ public class HachiController implements GridListener, Clockable, Receiver {
                 triggerables.add((Triggerable) modules[i]);
             }
 
+            if (modules[i] instanceof Chordable) {
+                chordables.add((Chordable) modules[i]);
+            }
+
             if (shihaiModule == null && modules[i] instanceof ShihaiModule) {
                 shihaiModule = (ShihaiModule)modules[i];
             }
         }
+
+        chordReceiver = new ChordReceiver(chordables);
 
     }
 
@@ -322,24 +332,17 @@ public class HachiController implements GridListener, Clockable, Receiver {
 
             } else {
                 switch (command) {
-//                    case NOTE_ON:
-////                        System.out.printf("NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
-//                        if (shortMessage.getChannel() == triggerChannel && shortMessage.getData1() == stepNote &&
-//                                shortMessage.getData2() >= STEP_MIN && shortMessage.getData2() <= STEP_MAX) {
-//                            sequencer.trigger(false);
-//                        } else if (shortMessage.getChannel() == triggerChannel && shortMessage.getData1() == stepNote &&
-//                                shortMessage.getData2() >= RESET_MIN && shortMessage.getData2() <= RESET_MAX) {
-//                            sequencer.trigger(true);
-//                        }
-//                        break;
-//                    case NOTE_OFF:
-////                        System.out.println("NOTE OFF");
-//                        break;
-//                    case CONTROL_CHANGE:
-////                        System.out.println("MIDI CC");
-//                        break;
-//                    default:
-////                        System.out.printf("MSG: %d\n", command);
+                    case NOTE_ON:
+                        System.out.printf("NOTE ON: %d, %d, %d\n", shortMessage.getChannel(), shortMessage.getData1(), shortMessage.getData2());
+                        break;
+                    case NOTE_OFF:
+                        System.out.println("NOTE OFF");
+                        break;
+                    case CONTROL_CHANGE:
+//                        System.out.println("MIDI CC");
+                        break;
+                    default:
+//                        System.out.printf("MSG: %d\n", command);
                 }
             }
         }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/ChordModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/ChordModule.java
@@ -21,6 +21,7 @@ public class ChordModule extends MidiModule implements Chordable {
     protected Chord chord = null;
 
     // remember what notes we actually played for input note numbers, so we can stop them later
+    // maps to a list rather than a set because some synths (e.g. Sub 37) track multiple ons/offs for same note
     private Map<Integer, List<Integer>> playedNotesMap = Maps.newHashMap();
 
 
@@ -61,7 +62,7 @@ public class ChordModule extends MidiModule implements Chordable {
 
         } else {
             // note on -- once we compute any mapping, add those mappings to the playedNotesMap
-            int mappedNote = noteNumber;                                                                                // have to add notes more than once for sub37
+            int mappedNote = noteNumber;
             if (chord != null && !chord.isEmpty()) {
                 mappedNote = chord.mapNote(noteNumber);
 //                System.out.printf("- mapped %d to %d\n", noteNumber, mappedNote);

--- a/src/main/java/net/perkowitz/issho/hachi/modules/ChordModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/ChordModule.java
@@ -1,0 +1,92 @@
+package net.perkowitz.issho.hachi.modules;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import net.perkowitz.issho.hachi.Chord;
+import net.perkowitz.issho.hachi.Chordable;
+
+import javax.sound.midi.*;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by optic on 10/24/16.
+ */
+public class ChordModule extends MidiModule implements Chordable {
+
+    protected Chord chord = null;
+
+    // remember what notes we actually played for input note numbers, so we can stop them later
+    private Map<Integer, List<Integer>> playedNotesMap = Maps.newHashMap();
+
+
+    public ChordModule(Transmitter inputTransmitter, Receiver outputReceiver) {
+        super(inputTransmitter, outputReceiver);
+    }
+
+
+    /***** chordable implementation ********************************/
+
+    public void setChord(Chord chord) {
+        this.chord = chord;
+    }
+
+
+    /************************************************************************
+     * midi output implementation
+     *
+     */
+
+    @Override
+    protected void sendMidiNote(int channel, int noteNumber, int velocity) {
+
+        if (isMuted && velocity > 0) return;
+//        System.out.printf("ChordModule Note: ch=%d, note=%d, vel=%d\n", channel, noteNumber, velocity);
+
+        if (velocity == 0) {
+            // note off -- send note off for any notes we mapped this note number to
+            Collection<Integer> mappedNotes = playedNotesMap.get(noteNumber);
+            if (mappedNotes == null || mappedNotes.isEmpty()) {
+                mappedNotes = Sets.newHashSet(noteNumber);
+            }
+            for (Integer mappedNote : mappedNotes) {
+//                System.out.printf("- mapped note off for %d to %d\n", noteNumber, mappedNote);
+                send(channel, mappedNote, velocity);
+            }
+            playedNotesMap.put(noteNumber, Lists.<Integer>newArrayList());
+
+        } else {
+            // note on -- once we compute any mapping, add those mappings to the playedNotesMap
+            int mappedNote = noteNumber;                                                                                // have to add notes more than once for sub37
+            if (chord != null && !chord.isEmpty()) {
+                mappedNote = chord.mapNote(noteNumber);
+//                System.out.printf("- mapped %d to %d\n", noteNumber, mappedNote);
+            }
+
+            if (playedNotesMap.get(noteNumber) == null) {
+                playedNotesMap.put(noteNumber, Lists.<Integer>newArrayList(mappedNote));
+            } else {
+                playedNotesMap.get(noteNumber).add(mappedNote);
+            }
+            send(channel, mappedNote, velocity);
+
+        }
+
+
+    }
+
+    protected void send(int channel, int noteNumber, int velocity) {
+        try {
+            ShortMessage noteMessage = new ShortMessage();
+            noteMessage.setMessage(ShortMessage.NOTE_ON, channel, noteNumber, velocity);
+            outputReceiver.send(noteMessage, -1);
+        } catch (InvalidMidiDataException e) {
+            System.err.println(e);
+        }
+    }
+
+}

--- a/src/main/java/net/perkowitz/issho/hachi/modules/MidiModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/MidiModule.java
@@ -12,7 +12,7 @@ import static javax.sound.midi.ShortMessage.NOTE_OFF;
 public class MidiModule extends BasicModule implements Receiver {
 
     public static int MIDI_ALL_NOTES_OFF_CC = 123;
-    private static int MIDI_REALTIME_COMMAND = 0xF0;
+    public static int MIDI_REALTIME_COMMAND = 0xF0;
 
     protected Transmitter inputTransmitter;
     protected Receiver outputReceiver;
@@ -48,7 +48,7 @@ public class MidiModule extends BasicModule implements Receiver {
     }
 
     protected void sendMidiNote(int channel, int noteNumber, int velocity) {
-//        System.out.printf("Note: ch=%d, note=%d, vel=%d\n", channel, noteNumber, velocity);
+//        System.out.printf("MidiModule Note: ch=%d, note=%d, vel=%d\n", channel, noteNumber, velocity);
 
         if (isMuted && velocity > 0) return;
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/example/ExampleModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/example/ExampleModule.java
@@ -2,10 +2,7 @@ package net.perkowitz.issho.hachi.modules.example;
 
 import com.google.common.io.Files;
 import net.perkowitz.issho.devices.*;
-import net.perkowitz.issho.hachi.Chordable;
-import net.perkowitz.issho.hachi.Clockable;
-import net.perkowitz.issho.hachi.Saveable;
-import net.perkowitz.issho.hachi.Sessionizeable;
+import net.perkowitz.issho.hachi.*;
 import net.perkowitz.issho.hachi.modules.*;
 import net.perkowitz.issho.hachi.modules.step.*;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -21,7 +18,7 @@ import static net.perkowitz.issho.hachi.modules.example.ExampleUtil.*;
 /**
  * Created by optic on 10/24/16.
  */
-public class ExampleModule extends MidiModule implements Module, Clockable, GridListener, Sessionizeable, Chordable, Saveable, Muteable {
+public class ExampleModule extends MidiModule implements Module, Clockable, GridListener, Sessionizeable, Saveable, Muteable {
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -133,7 +130,7 @@ public class ExampleModule extends MidiModule implements Module, Clockable, Grid
      * 
      * @param notes
      */
-    public void setChordNotes(List<Integer> notes) {
+    public void setChord(Chord chord) {
 
     }
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/mono/MonoModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/mono/MonoModule.java
@@ -5,13 +5,8 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import net.perkowitz.issho.devices.*;
 import net.perkowitz.issho.devices.launchpadpro.Color;
-import net.perkowitz.issho.hachi.Chordable;
-import net.perkowitz.issho.hachi.Clockable;
-import net.perkowitz.issho.hachi.Saveable;
-import net.perkowitz.issho.hachi.Sessionizeable;
-import net.perkowitz.issho.hachi.modules.MidiModule;
-import net.perkowitz.issho.hachi.modules.Module;
-import net.perkowitz.issho.hachi.modules.Muteable;
+import net.perkowitz.issho.hachi.*;
+import net.perkowitz.issho.hachi.modules.*;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import javax.sound.midi.Receiver;
@@ -30,7 +25,7 @@ import static net.perkowitz.issho.hachi.modules.mono.MonoUtil.View.SEQUENCE;
 /**
  * Created by optic on 10/24/16.
  */
-public class MonoModule extends MidiModule implements Module, Clockable, GridListener, Sessionizeable, Chordable, Saveable, Muteable {
+public class MonoModule extends ChordModule implements Module, Clockable, GridListener, Sessionizeable, Saveable, Muteable {
 
     private static int MAX_VELOCITY = 127;
     private static int MAX_OCTAVE = 7;
@@ -58,6 +53,8 @@ public class MonoModule extends MidiModule implements Module, Clockable, GridLis
 
     private String filePrefix = "monomodule";
     private int currentFileIndex = 0;
+
+    private int transpose = 0;
 
 
     /***** Constructor ****************************************/
@@ -109,7 +106,7 @@ public class MonoModule extends MidiModule implements Module, Clockable, GridLis
             notesOff();
         } else if (step.isEnabled() && step.getGate() == PLAY) {
             notesOff();
-            sendMidiNote(memory.getMidiChannel(), step.getNote(), step.getVelocity());
+            sendMidiNote(memory.getMidiChannel(), transpose + step.getNote(), step.getVelocity());
             onNotes.add(step.getNote());
         } else if (step.isEnabled() && step.getGate() == MonoUtil.Gate.TIE) {
             // do nothing
@@ -135,7 +132,7 @@ public class MonoModule extends MidiModule implements Module, Clockable, GridLis
 
     private void notesOff() {
         for (Integer note : onNotes) {
-            sendMidiNote(memory.getMidiChannel(), note, 0);
+            sendMidiNote(memory.getMidiChannel(), transpose + note, 0);
 
         }
         onNotes.clear();
@@ -232,8 +229,9 @@ public class MonoModule extends MidiModule implements Module, Clockable, GridLis
 
     /***** Chordable implementation ***********************************/
 
-    public void setChordNotes(List<Integer> notes) {
-
+    public void xxxxxsetChord(Chord chord) {
+        System.out.printf("MonoModule.setChord: %s\n", chord);
+        transpose = chord.getTranspose();
     }
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/mono/MonoModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/mono/MonoModule.java
@@ -227,14 +227,6 @@ public class MonoModule extends ChordModule implements Module, Clockable, GridLi
         return isMuted;
     }
 
-    /***** Chordable implementation ***********************************/
-
-    public void xxxxxsetChord(Chord chord) {
-        System.out.printf("MonoModule.setChord: %s\n", chord);
-        transpose = chord.getTranspose();
-    }
-
-
     /***** Sessionizeable implementation *************************************/
 
     public void selectSession(int index) {

--- a/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
@@ -91,7 +91,6 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
 
     private void playStep(Step step) {
 
-        System.out.printf("playStep: %s\n", step);
         List<Integer> noteIndices = Lists.newArrayList();
         switch (step.getMode()) {
             case Play:
@@ -158,7 +157,6 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
     }
 
     private void notesOff() {
-        System.out.printf("notesOff: %s\n", onNotes);
         for (Integer note : onNotes) {
             sendMidiNote(memory.getMidiChannel(), note, 0);
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
@@ -4,10 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import net.perkowitz.issho.devices.*;
-import net.perkowitz.issho.hachi.Chordable;
-import net.perkowitz.issho.hachi.Clockable;
-import net.perkowitz.issho.hachi.Saveable;
-import net.perkowitz.issho.hachi.Sessionizeable;
+import net.perkowitz.issho.hachi.*;
 import net.perkowitz.issho.hachi.modules.*;
 import org.codehaus.jackson.map.ObjectMapper;
 
@@ -23,7 +20,7 @@ import static net.perkowitz.issho.hachi.modules.step.StepUtil.*;
 /**
  * Created by optic on 10/24/16.
  */
-public class StepModule extends MidiModule implements Module, Clockable, GridListener, Sessionizeable, Chordable, Saveable, Muteable {
+public class StepModule extends ChordModule implements Module, Clockable, GridListener, Sessionizeable, Saveable, Muteable {
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -94,6 +91,7 @@ public class StepModule extends MidiModule implements Module, Clockable, GridLis
 
     private void playStep(Step step) {
 
+        System.out.printf("playStep: %s\n", step);
         List<Integer> noteIndices = Lists.newArrayList();
         switch (step.getMode()) {
             case Play:
@@ -160,6 +158,7 @@ public class StepModule extends MidiModule implements Module, Clockable, GridLis
     }
 
     private void notesOff() {
+        System.out.printf("notesOff: %s\n", onNotes);
         for (Integer note : onNotes) {
             sendMidiNote(memory.getMidiChannel(), note, 0);
 
@@ -200,13 +199,6 @@ public class StepModule extends MidiModule implements Module, Clockable, GridLis
 
     public boolean isMuted() {
         return isMuted;
-    }
-
-
-    /***** Chordable implementation ***********************************/
-
-    public void setChordNotes(List<Integer> notes) {
-
     }
 
 

--- a/src/main/resources/hachi-dev.json
+++ b/src/main/resources/hachi-dev.json
@@ -14,13 +14,17 @@
         "Midi Port"
         ]
     },
-    "knobby": {
-      "names":[
-        "nanokontrol"
-        ]
+    "keyboard": {
+      "names": [
+        "LPK25"
+      ]
     }
   },
   "modules": [
+    {
+      "class": "StepModule",
+      "filePrefix": "step0"
+    },
     {
       "class": "ExampleModule",
       "filePrefix": "example0"

--- a/src/main/resources/hachi-dev.json
+++ b/src/main/resources/hachi-dev.json
@@ -18,6 +18,7 @@
       "names": [
         "LPK25"
       ],
+      "chordHoldEnabled": true,
       "holdClearControllerNumber": 64
     }
   },

--- a/src/main/resources/hachi-dev.json
+++ b/src/main/resources/hachi-dev.json
@@ -17,7 +17,8 @@
     "keyboard": {
       "names": [
         "LPK25"
-      ]
+      ],
+      "holdClearControllerNumber": 64
     }
   },
   "modules": [

--- a/src/main/resources/hachi-mac.json
+++ b/src/main/resources/hachi-mac.json
@@ -14,9 +14,14 @@
         "Midi Port"
         ]
     },
-    "knobby": {
+    "knobbyx": {
       "names":[
         "nanokontrol"
+      ]
+    },
+    "keyboard": {
+      "names": [
+        "LPK25"
       ]
     }
   },

--- a/src/main/resources/hachi-mac.json
+++ b/src/main/resources/hachi-mac.json
@@ -23,6 +23,7 @@
       "names": [
         "LPK25"
       ],
+      "chordHoldEnabled": true,
       "holdClearControllerNumber": 64
     }
   },

--- a/src/main/resources/hachi-mac.json
+++ b/src/main/resources/hachi-mac.json
@@ -22,7 +22,8 @@
     "keyboard": {
       "names": [
         "LPK25"
-      ]
+      ],
+      "holdClearControllerNumber": 64
     }
   },
   "modules": [

--- a/src/main/resources/hachi-pi.json
+++ b/src/main/resources/hachi-pi.json
@@ -23,6 +23,7 @@
       "names": [
         "LPK25"
       ],
+      "chordHoldEnabled": true,
       "holdClearControllerNumber": 64
     }
   },

--- a/src/main/resources/hachi-pi.json
+++ b/src/main/resources/hachi-pi.json
@@ -18,6 +18,12 @@
       "names":[
         "nanokontrol"
       ]
+    },
+    "keyboard": {
+      "names": [
+        "LPK25"
+      ],
+      "holdClearControllerNumber": 64
     }
   },
   "modules": [

--- a/src/test/java/net/perkowitz/issho/hachi/ChordReceiverTest.java
+++ b/src/test/java/net/perkowitz/issho/hachi/ChordReceiverTest.java
@@ -1,0 +1,189 @@
+package net.perkowitz.issho.hachi;
+
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.sound.midi.ShortMessage;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by optic on 12/26/16.
+ */
+public class ChordReceiverTest {
+
+    ChordReceiver chordReceiver;
+    Chordable chordable;
+
+    @Before
+    public void setUp() throws Exception {
+        chordable = mock(Chordable.class);
+        chordReceiver = new ChordReceiver(Lists.newArrayList(chordable));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void testChordSent() throws Exception {
+        ShortMessage message = createNoteOnMessage(0, 60, 64);
+        chordReceiver.send(message, -1);
+        verify(chordable, times(1)).setChord(any(Chord.class));
+        reset(chordable);
+
+        message = createNoteOnMessage(0, 60, 0);
+        chordReceiver.send(message, -1);
+        verify(chordable, times(1)).setChord(any(Chord.class));
+        reset(chordable);
+
+        message = createNoteOffMessage(0, 60, 64);
+        chordReceiver.send(message, -1);
+        verify(chordable, times(1)).setChord(any(Chord.class));
+        reset(chordable);
+    }
+
+    @Test
+    public void testNoteOnOff() throws Exception {
+
+        int note = 40;
+        ShortMessage noteOnMessage = createNoteOnMessage(0, note, 64);
+        ShortMessage noteOffMessage = createNoteOffMessage(0, note, 64);
+
+        // make sure chord includes note
+        chordReceiver.send(noteOnMessage, -1);
+        ArgumentCaptor<Chord> chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 1, true);
+        reset(chordable);
+
+        // make sure chord no longer contains note
+        chordReceiver.send(noteOffMessage, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 0, false);
+        reset(chordable);
+
+    }
+
+    @Test
+    public void testDuplicateNote() throws Exception {
+
+        int note = 56;
+        ShortMessage noteOnMessage = createNoteOnMessage(0, note, 64);
+        ShortMessage noteOffMessage = createNoteOffMessage(0, note, 64);
+        ShortMessage noteOnMessage2 = createNoteOnMessage(0, note + 12, 64);
+        ShortMessage noteOnMessage3 = createNoteOnMessage(0, note - 12, 64);
+
+        // make sure chord includes note
+        chordReceiver.send(noteOnMessage, -1);
+        ArgumentCaptor<Chord> chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 1, true);
+        reset(chordable);
+
+        // make sure chord includes note only once
+        chordReceiver.send(noteOnMessage, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 1, true);
+        reset(chordable);
+
+        // make sure chord includes note only once
+        chordReceiver.send(noteOnMessage2, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 1, true);
+        reset(chordable);
+
+        // make sure chord includes note only once
+        chordReceiver.send(noteOnMessage3, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 1, true);
+        reset(chordable);
+
+        // make sure chord no longer contains note
+        chordReceiver.send(noteOffMessage, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note, 0, false);
+        reset(chordable);
+
+    }
+
+    @Test
+    public void testMultipleNotes() throws Exception {
+
+        int note1 = 36;
+        int note2 = 43;
+        ShortMessage note1OnMessage = createNoteOnMessage(0, note1, 64);
+        ShortMessage note1OffMessage = createNoteOffMessage(0, note1, 64);
+        ShortMessage note2OnMessage = createNoteOnMessage(0, note2, 64);
+        ShortMessage note2OffMessage = createNoteOffMessage(0, note2, 64);
+
+        // make sure chord includes note1
+        chordReceiver.send(note1OnMessage, -1);
+        ArgumentCaptor<Chord> chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note1, 1, true);
+        reset(chordable);
+
+        // make sure chord includes note2 (and note1)
+        chordReceiver.send(note2OnMessage, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note2, 2, true);
+        checkChordForNote(chordCaptor.getValue(), note1, 2, true);
+        reset(chordable);
+
+        // make sure chord no longer contains note1 (but still contains note2)
+        chordReceiver.send(note1OffMessage, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note1, 1, false);
+        checkChordForNote(chordCaptor.getValue(), note2, 1, true);
+        reset(chordable);
+
+        // make sure chord no longer contains note2 (or note1)
+        chordReceiver.send(note2OffMessage, -1);
+        chordCaptor = ArgumentCaptor.forClass(Chord.class);
+        verify(chordable, times(1)).setChord(chordCaptor.capture());
+        checkChordForNote(chordCaptor.getValue(), note2, 0, false);
+        checkChordForNote(chordCaptor.getValue(), note1, 0, false);
+        reset(chordable);
+
+    }
+
+
+    /***** helper methods *****************************************/
+
+    private ShortMessage createNoteOnMessage(int channel, int noteNumber, int velocity) throws Exception {
+        ShortMessage message = new ShortMessage();
+        message.setMessage(ShortMessage.NOTE_ON, channel, noteNumber, velocity);
+        return message;
+    }
+
+    private ShortMessage createNoteOffMessage(int channel, int noteNumber, int velocity) throws Exception {
+        ShortMessage message = new ShortMessage();
+        message.setMessage(ShortMessage.NOTE_OFF, channel, noteNumber, velocity);
+        return message;
+    }
+
+    private void checkChordForNote(Chord chord, int note, int totalSize, boolean shouldContainNote) {
+        assertEquals(totalSize, chord.size());
+        List<Integer> baseNotes = chord.getBaseNotes();
+        assertEquals(totalSize, baseNotes.size());
+        assertEquals(shouldContainNote, baseNotes.contains(note % 12));
+    }
+
+}

--- a/src/test/java/net/perkowitz/issho/hachi/ChordTest.java
+++ b/src/test/java/net/perkowitz/issho/hachi/ChordTest.java
@@ -1,0 +1,166 @@
+package net.perkowitz.issho.hachi;
+
+import com.google.common.collect.Sets;
+import net.perkowitz.issho.devices.GridButton;
+import net.perkowitz.issho.devices.GridListener;
+import net.perkowitz.issho.devices.GridPad;
+import net.perkowitz.issho.devices.launchpadpro.Color;
+import net.perkowitz.issho.devices.launchpadpro.LaunchpadPro;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.ShortMessage;
+
+import static javax.sound.midi.ShortMessage.CONTROL_CHANGE;
+import static javax.sound.midi.ShortMessage.NOTE_ON;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by optic on 12/26/16.
+ */
+public class ChordTest {
+
+    int[] defaultMapping = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void testEmpty() throws Exception {
+        Chord chord = new Chord();
+        assertEquals(true, chord.isEmpty());
+
+        chord.add(0);
+        assertEquals(false, chord.isEmpty());
+
+        chord.clear();
+        assertEquals(true, chord.isEmpty());
+    }
+
+    @Test
+    public void testAddRemove() throws Exception {
+        Chord chord = new Chord();
+        assertEquals(true, chord.isEmpty());
+        assertEquals(0, chord.size());
+
+        chord.add(0);
+        assertEquals(false, chord.isEmpty());
+        assertEquals(1, chord.size());
+
+        chord.remove(0);
+        assertEquals(true, chord.isEmpty());
+        assertEquals(0, chord.size());
+
+        chord.add(-1);
+        chord.add(-1000);
+        chord.add(null);
+        assertEquals(true, chord.isEmpty());
+    }
+
+    @Test
+    public void testMod() throws Exception {
+        Chord chord = new Chord();
+        assertEquals(0, chord.size());
+
+        chord.add(0);
+        assertEquals(1, chord.size());
+        chord.add(12);
+        assertEquals(1, chord.size());
+        chord.add(24);
+        assertEquals(1, chord.size());
+
+        chord.add(3);
+        assertEquals(2, chord.size());
+        chord.add(123);
+        assertEquals(2, chord.size());
+    }
+
+    @Test
+    public void testDefaultMapping() throws Exception {
+        Chord chord = new Chord();
+        verifyMapping(chord, defaultMapping);
+
+        chord.add(0);
+        chord.clear();
+        verifyMapping(chord, defaultMapping);
+    }
+
+    @Test
+    public void testNoMapping() throws Exception {
+        Chord chord = new Chord();
+        chord.setNoteMapMode(Chord.NoteMapMode.NO_MAP);
+        verifyMapping(chord, defaultMapping);
+
+        chord.add(0);
+        verifyMapping(chord, defaultMapping);
+    }
+
+    @Test
+    public void testFloorMapping() throws Exception {
+        Chord chord = new Chord();
+        chord.setNoteMapMode(Chord.NoteMapMode.FLOOR);
+        verifyMapping(chord, defaultMapping);
+
+        chord.add(0);
+        verifyMapping(chord, new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
+        chord.add(4);
+        chord.add(7);
+        verifyMapping(chord, new int[] { 0, 0, 0, 0, 4, 4, 4, 7, 7, 7, 7, 7 });
+    }
+
+    @Test
+    public void testNearestMapping() throws Exception {
+        Chord chord = new Chord();
+        chord.setNoteMapMode(Chord.NoteMapMode.NEAREST);
+        verifyMapping(chord, defaultMapping);
+
+        chord.add(0);
+        verifyMapping(chord, new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
+        chord.add(4);
+        chord.add(7);
+        verifyMapping(chord, new int[] { 0, 0, 4, 4, 4, 4, 7, 7, 7, 7, 0, 0 });
+    }
+
+    @Test
+    public void testRoundRobinMapping() throws Exception {
+        Chord chord = new Chord();
+        chord.setNoteMapMode(Chord.NoteMapMode.ROUND_ROBIN);
+        verifyMapping(chord, defaultMapping);
+
+        chord.add(0);
+        verifyMapping(chord, new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
+        chord.add(4);
+        chord.add(7);
+        verifyMapping(chord, new int[] { 0, 4, 7, 0, 4, 7, 0, 4, 7, 0, 4, 7 });
+    }
+
+
+
+
+
+    /***** helper methods *****************************************/
+
+    private void verifyMapping(Chord chord, int[] mapping) {
+        for (int n = 0; n < 12; n++) {
+            assertEquals(mapping[n], chord.mapNote(n));
+        }
+    }
+
+
+}


### PR DESCRIPTION
This update implements the "Chordable" interface by allowing Hachi to receive notes from an attached
USB midi keyboard, track the current chord being played, pass it to Chordable modules, and have those modules alter their note output accordingly. Works with both MonoModule and StepModule. In both cases, playing a chord will remap all notes to one of the notes in the chord as long as the chord is held down. 

- Keyboard class
- Chord class that defines a chord (a collection of notes) and can do note mapping
- ChordModule that inherits from MidiModule, implements Chordable, and does the note remapping (and the tracking necessary to send note off properly, even if the chord changes) when sending midi
- ChordListener that implements the logic for listening to midi notes and deciding what the current chord is
