### PR TITLE
Add processing of 24 ppqn MIDI clock, enable swing in some modules

### DIFF
--- a/src/main/java/net/perkowitz/issho/devices/FindDevices.java
+++ b/src/main/java/net/perkowitz/issho/devices/FindDevices.java
@@ -15,17 +15,7 @@ public class FindDevices {
 
     public static void main(String args[]) throws Exception {
 
-        String[] names = new String[] { "NoSuchDevice" };
-        input = MidiUtil.findMidiDevice(names, false, true);
-        if (input == null) {
-            System.err.printf("Unable to find controller input device matching name: %s\n", StringUtils.join(names, ", "));
-            System.exit(1);
-        }
-//        output = MidiUtil.findMidiDevice(names, true, false);
-//        if (output == null) {
-//            System.err.printf("Unable to find controller output device matching name: %s\n", StringUtils.join(names, ", "));
-//            System.exit(1);
-//        }
+        MidiUtil.printMidiDevices();
 
     }
 

--- a/src/main/java/net/perkowitz/issho/hachi/Clockable.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Clockable.java
@@ -8,5 +8,6 @@ public interface Clockable {
     public void start(boolean restart);
     public void stop();
     public void tick(boolean andReset);
+    public void clock(int measure, int beat, int pulse);
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/HachiController.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiController.java
@@ -34,6 +34,11 @@ public class HachiController implements Clockable, Receiver {
     private int stepNote = 65;//36;
     private int midiClockDivider = 6;
     private int midiClockCount = 0;
+    private int clockMeasure = 0;
+    private int clockBeat = 0;
+    private int clockPulse = 0;
+    private int clockPulsesPerBeat = 24;
+    private int clockBeatsPerMeasure = 4;
 
     private Module[] modules = null;
     private GridDevice[] gridDevices;
@@ -228,6 +233,15 @@ public class HachiController implements Clockable, Receiver {
         }
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        if (midiClockRunning) {
+            for (Clockable clockable : clockables) {
+                clockable.clock(measure, beat, pulse);
+            }
+        }
+
+    }
+
 
     /***** Receiver implementation ***************/
 
@@ -258,11 +272,31 @@ public class HachiController implements Clockable, Receiver {
                         break;
                     case TIMING_CLOCK:
 //                        System.out.println("TICK");
+//                        System.out.printf("  Tick: %d, %d\n", midiClockCount, tickCount);
                         if (midiClockCount % midiClockDivider == 0) {
                             boolean andReset = (tickCount % 16 == 0);
-                            this.tick(andReset);
+//                            this.tick(andReset);
+//                            System.out.printf("  Sending tick, reset=%s\n", andReset);
                             tickCount++;
                         }
+
+                        this.clock(clockMeasure, clockBeat, clockPulse);
+//                        if (clockPulse == 0) {
+//                            System.out.printf("  Clock: %04d:%02d:%02d\n", clockMeasure, clockBeat, clockPulse);
+//                        }
+                        clockPulse++;
+                        if (clockPulse % clockPulsesPerBeat == 0 && clockPulse > 0) {
+                            clockPulse = 0;
+                            clockBeat++;
+//                            System.out.println("  Incrementing clockBeat");
+                        }
+                        if (clockBeat % clockBeatsPerMeasure == 0 && clockBeat > 0) {
+                            clockBeat = 0;
+                            clockMeasure++;
+//                            System.out.println("  Incrementing clockMeasure");
+                        }
+
+
                         midiClockCount++;
                         break;
                     default:

--- a/src/main/java/net/perkowitz/issho/hachi/modules/ClockModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/ClockModule.java
@@ -84,5 +84,11 @@ public class ClockModule extends BasicModule implements Clockable {
         drawClock();
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/DrawingModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/DrawingModule.java
@@ -196,6 +196,13 @@ public class DrawingModule extends BasicModule implements Clockable {
         tickCount++;
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
+
 
     /***** private implementation ****************************************/
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/SettingsSubmodule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/SettingsSubmodule.java
@@ -20,6 +20,7 @@ public class SettingsSubmodule extends BasicModule implements Module, Sessionize
     @Getter @Setter private int nextSessionIndex = 0;
     @Getter @Setter private int currentFileIndex = 0;
     @Getter @Setter private int midiChannel = 0;
+    @Getter @Setter private int swingOffset = 0;
     @Getter private SettingsUtil.SettingsChanged settingsChanged = SettingsUtil.SettingsChanged.NONE;
 
     private Map<Integer, Color> palette = SettingsUtil.PALETTE;
@@ -27,16 +28,18 @@ public class SettingsSubmodule extends BasicModule implements Module, Sessionize
     private boolean includeSessions = true;
     private boolean includeFiles = true;
     private boolean includeMidiChannel = true;
+    private boolean includeSwing = false;
 
 
     /***** constructor ***********************************/
 
     public SettingsSubmodule() {}
 
-    public SettingsSubmodule(boolean includeSessions, boolean includeFiles, boolean includeMidiChannel) {
+    public SettingsSubmodule(boolean includeSessions, boolean includeFiles, boolean includeMidiChannel, boolean includeSwing) {
         this.includeSessions = includeSessions;
         this.includeFiles = includeFiles;
         this.includeMidiChannel = includeMidiChannel;
+        this.includeSwing = includeSwing;
     }
 
     /***** Module implementation ***********************************/
@@ -48,6 +51,7 @@ public class SettingsSubmodule extends BasicModule implements Module, Sessionize
         drawSessions();
         drawFiles();
         drawMidiChannel();
+        drawSwing();
         settingsChanged = SettingsUtil.SettingsChanged.NONE;
     }
 
@@ -85,6 +89,11 @@ public class SettingsSubmodule extends BasicModule implements Module, Sessionize
             midiChannel = SettingsUtil.midiChannelControls.getIndex(control);
             drawMidiChannel();
             return SettingsUtil.SettingsChanged.SET_MIDI_CHANNEL;
+
+        } else if (SettingsUtil.swingControls.contains(control)) {
+            swingOffset = SettingsUtil.swingControls.getIndex(control) - 3;
+            drawSwing();
+            return SettingsChanged.SET_SWING;
         }
 
         return SettingsUtil.SettingsChanged.NONE;
@@ -130,6 +139,17 @@ public class SettingsSubmodule extends BasicModule implements Module, Sessionize
             Color color = palette.get(COLOR_MIDI_CHANNEL);
             if (control.getIndex() == midiChannel) {
                 color = palette.get(COLOR_MIDI_CHANNEL_ACTIVE);
+            }
+            control.draw(display, color);
+        }
+    }
+
+    public void drawSwing() {
+        if (!includeSwing) return;
+        for (GridControl control : swingControls.getControls()) {
+            Color color = palette.get(COLOR_SWING);
+            if (control.getIndex() == swingOffset + 3) {
+                color = palette.get(COLOR_SWING_ACTIVE);
             }
             control.draw(display, color);
         }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/SettingsUtil.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/SettingsUtil.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class SettingsUtil {
 
     public enum SettingsChanged {
-        NONE, SELECT_SESSION, LOAD_FILE, SAVE_FILE, SET_MIDI_CHANNEL
+        NONE, SELECT_SESSION, LOAD_FILE, SAVE_FILE, SET_MIDI_CHANNEL, SET_SWING
     }
 
     /***** locations of various controls on the grid ************************/
@@ -25,6 +25,7 @@ public class SettingsUtil {
     public static int SESSION_MAX_ROW = 1;
     public static int FILE_LOAD_ROW = 2;
     public static int FILE_SAVE_ROW = 3;
+    public static int SWING_ROW = 5;
     public static int MIDI_CHANNEL_MIN_ROW = 6;
     public static int MIDI_CHANNEL_MAX_ROW = 7;
 
@@ -35,6 +36,7 @@ public class SettingsUtil {
     public static GridControlSet loadControls = GridControlSet.padRows(SettingsUtil.FILE_LOAD_ROW, SettingsUtil.FILE_LOAD_ROW);
     public static GridControlSet saveControls = GridControlSet.padRows(SettingsUtil.FILE_SAVE_ROW, SettingsUtil.FILE_SAVE_ROW);
     public static GridControlSet midiChannelControls = GridControlSet.padRows(SettingsUtil.MIDI_CHANNEL_MIN_ROW, SettingsUtil.MIDI_CHANNEL_MAX_ROW);
+    public static GridControlSet swingControls = GridControlSet.padRows(SettingsUtil.SWING_ROW, SettingsUtil.SWING_ROW);
 
 
     /***** color palettes **********************************************************/
@@ -49,6 +51,8 @@ public class SettingsUtil {
     public static Integer COLOR_FILE_ACTIVE = 22;
     public static Integer COLOR_MIDI_CHANNEL = 23;
     public static Integer COLOR_MIDI_CHANNEL_ACTIVE = 24;
+    public static Integer COLOR_SWING = 25;
+    public static Integer COLOR_SWING_ACTIVE = 26;
 
     public static Map<Integer, Color> PALETTE = Maps.newHashMap();
     static {
@@ -62,6 +66,8 @@ public class SettingsUtil {
         PALETTE.put(COLOR_FILE_ACTIVE, Color.WHITE);
         PALETTE.put(COLOR_MIDI_CHANNEL, Color.DIM_BLUE);
         PALETTE.put(COLOR_MIDI_CHANNEL_ACTIVE, Color.WHITE);
+        PALETTE.put(COLOR_SWING, Color.DIM_PINK);
+        PALETTE.put(COLOR_SWING_ACTIVE, Color.WHITE);
     }
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/beatbox/BeatModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/beatbox/BeatModule.java
@@ -65,7 +65,7 @@ public class BeatModule extends MidiModule implements Module, Clockable, GridLis
         this.beatDisplay.setPalette(palette);
         this.filePrefix = filePrefix;
         load(0);
-        this.settingsModule = new SettingsSubmodule();
+        this.settingsModule = new SettingsSubmodule(true, true, true, true);
     }
 
 
@@ -90,6 +90,7 @@ public class BeatModule extends MidiModule implements Module, Clockable, GridLis
             if (nextSessionIndex != null && nextSessionIndex != memory.getCurrentSessionIndex()) {
                 memory.selectSession(nextSessionIndex);
                 settingsModule.setCurrentSessionIndex(nextSessionIndex);
+                settingsModule.setSwingOffset(memory.getCurrentSession().getSwingOffset());
                 nextSessionIndex = null;
             }
 
@@ -414,6 +415,9 @@ public class BeatModule extends MidiModule implements Module, Clockable, GridLis
             case SET_MIDI_CHANNEL:
                 memory.setMidiChannel(settingsModule.getMidiChannel());
                 break;
+            case SET_SWING:
+                memory.getCurrentSession().setSwingOffset(settingsModule.getSwingOffset());
+                break;
         }
     }
 
@@ -508,6 +512,11 @@ public class BeatModule extends MidiModule implements Module, Clockable, GridLis
         }
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        if ((pulse == 0 || pulse == 6 + memory.getCurrentSession().getSwingOffset() || pulse == 12 || pulse == 18 + memory.getCurrentSession().getSwingOffset()) && playing) {
+            advance(beat == 0 && pulse == 0);
+        }
+    }
 
 
     /************************************************************************

--- a/src/main/java/net/perkowitz/issho/hachi/modules/beatbox/BeatSession.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/beatbox/BeatSession.java
@@ -19,6 +19,7 @@ public class BeatSession {
     @Getter private int chainStartIndex = 0;
     @Getter private int chainEndIndex = 0;
     @Getter @Setter private int selectedTrackIndex = 8;
+    @Getter @Setter private int swingOffset = 0;
 
 
     public BeatSession() {}

--- a/src/main/java/net/perkowitz/issho/hachi/modules/example/ExampleModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/example/ExampleModule.java
@@ -306,6 +306,13 @@ public class ExampleModule extends MidiModule implements Module, Clockable, Grid
         advance(andReset);
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
+
 
     /***** Saveable implementation ***************************************
      * 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/minibeat/MinibeatModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/minibeat/MinibeatModule.java
@@ -445,6 +445,12 @@ public class MinibeatModule extends MidiModule implements Module, Clockable, Gri
         }
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
 
 
     /************************************************************************

--- a/src/main/java/net/perkowitz/issho/hachi/modules/mono/MonoModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/mono/MonoModule.java
@@ -544,6 +544,13 @@ public class MonoModule extends ChordModule implements Module, Clockable, GridLi
         advance(andReset);
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
+
 
     /***** Saveable implementation ****************************************/
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/para/ParaModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/para/ParaModule.java
@@ -46,6 +46,7 @@ public class ParaModule extends ChordModule implements Module, Clockable, GridLi
     private int currentKeyboardOctave = 5;
     @Setter private boolean monophonic = false;
     @Setter int controlA = 1;
+    private int swingOffset = 0;
 
     private String filePrefix = "polymodule";
     private int currentFileIndex = 0;
@@ -61,7 +62,7 @@ public class ParaModule extends ChordModule implements Module, Clockable, GridLi
         paraDisplay.setPalette(palette);
         this.filePrefix = filePrefix;
         load(0);
-        this.settingsModule = new SettingsSubmodule();
+        this.settingsModule = new SettingsSubmodule(true, true, true, true);
     }
 
 
@@ -475,6 +476,9 @@ public class ParaModule extends ChordModule implements Module, Clockable, GridLi
             case SET_MIDI_CHANNEL:
                 memory.setMidiChannel(settingsModule.getMidiChannel());
                 break;
+            case SET_SWING:
+                swingOffset = settingsModule.getSwingOffset();
+                break;
         }
     }
 
@@ -559,6 +563,12 @@ public class ParaModule extends ChordModule implements Module, Clockable, GridLi
 
     public void tick(boolean andReset) {
         advance(andReset);
+    }
+
+    public void clock(int measure, int beat, int pulse) {
+        if (pulse == 0 || pulse == 6 + swingOffset || pulse == 12 || pulse == 18 + swingOffset) {
+            advance(beat == 0 && pulse == 0);
+        }
     }
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/rhythm/RhythmModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/rhythm/RhythmModule.java
@@ -628,6 +628,13 @@ public class RhythmModule implements Module, RhythmInterface, Clockable, Session
         advance(andReset);
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
+
 
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/shihai/ShihaiModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/shihai/ShihaiModule.java
@@ -52,7 +52,7 @@ public class ShihaiModule extends MidiModule implements Clockable {
     public ShihaiModule(Transmitter inputTransmitter, Receiver outputReceiver) {
         super(inputTransmitter, outputReceiver);
         this.shihaiDisplay = new ShihaiDisplay(display);
-        this.settingsModule = new SettingsSubmodule(true, false, false);
+        this.settingsModule = new SettingsSubmodule(true, false, false, false);
     }
 
 
@@ -269,6 +269,12 @@ public class ShihaiModule extends MidiModule implements Clockable {
         tickCount++;
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        // imitate old "tick" system of sending a tick per 16th note, and a reset on each measure
+        if (pulse % 6 == 0) {
+            tick(beat == 0 && pulse == 0);
+        }
+    }
 
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
@@ -45,6 +45,7 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
     private boolean randomOrder = false;
     private boolean displayAltControls = false;
     private boolean savingPattern = false;
+    int swingOffset = 0;
 
 
     /***** Constructor ****************************************/
@@ -55,7 +56,7 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
         this.filePrefix = filePrefix;
         load(0);
         currentSteps = currentStage().getSteps();
-        this.settingsModule = new SettingsSubmodule();
+        this.settingsModule = new SettingsSubmodule(true, true, true, true);
         currentMarker = Note;
         stepDisplay.setCurrentMarker(currentMarker);
     }
@@ -359,6 +360,9 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
                 notesOff();
                 memory.setMidiChannel(settingsModule.getMidiChannel());
                 break;
+            case SET_SWING:
+                swingOffset = settingsModule.getSwingOffset();
+                break;
         }
     }
 
@@ -403,6 +407,11 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
         advance(andReset);
     }
 
+    public void clock(int measure, int beat, int pulse) {
+        if (pulse == 0 || pulse == 6 + swingOffset || pulse == 12 || pulse == 18 + swingOffset) {
+            advance(beat == 0 && pulse == 0);
+        }
+    }
 
     /***** Saveable implementation ****************************************/
 

--- a/src/main/java/net/perkowitz/issho/util/MidiUtil.java
+++ b/src/main/java/net/perkowitz/issho/util/MidiUtil.java
@@ -42,12 +42,18 @@ public class MidiUtil {
             System.out.printf("MIDI not available: %s\n", e);
         }
 
-        // if device not found, print out a list of devices
+        return null;
+    }
+
+    public static void printMidiDevices() {
+        if (midiDeviceInfos == null) {
+            System.out.println("Loading device info..");
+            midiDeviceInfos = MidiSystem.getMidiDeviceInfo();
+        }
+
         for (int i = 0; i < midiDeviceInfos.length; i++) {
             System.out.printf("Found midi device: %s, %s\n", midiDeviceInfos[i].getName(), midiDeviceInfos[i].getDescription());
         }
-
-        return null;
     }
 
 }

--- a/src/main/resources/hachi-dev.json
+++ b/src/main/resources/hachi-dev.json
@@ -9,12 +9,6 @@
           "Launchpad",
           "Standalone"
         ]
-      },
-      {
-        "type": "launchpad",
-        "names": [
-          "Launchpad"
-        ]
       }
     ],
     "midi": {
@@ -34,41 +28,14 @@
   },
   "modules": [
     {
-      "class": "ShihaiModule",
-      "panicExclude": [14, 15]
-    },
-    {
       "class": "BeatModule",
       "palette": "Blue",
       "filePrefix": "beat0"
     },
     {
-      "class": "BeatModule",
-      "palette": "Pink",
-      "midiNoteOffset": 24,
-      "filePrefix": "beat1"
-    },
-    {
-      "class": "BeatModule",
-      "palette": "Green",
-      "filePrefix": "beat2"
-    },
-    {
-      "class": "ParaModule",
-      "palette": "pink",
-      "filePrefix": "para1",
-      "monophonic": true
-    },
-    {
       "class": "ParaModule",
       "palette": "yellow",
       "filePrefix": "para0",
-      "monophonic": false
-    },
-    {
-      "class": "ParaModule",
-      "palette": "blue",
-      "filePrefix": "para1",
       "monophonic": false
     },
     {

--- a/src/main/resources/hachi-mac.json
+++ b/src/main/resources/hachi-mac.json
@@ -2,12 +2,15 @@
   "filePrefix": "project1/",
   "midiContinueAsStart": true,
   "devices": {
-    "controller": {
-      "names": [
-        "Launchpad",
-        "Standalone"
+    "controllers": [
+      {
+        "type": "launchpadpro",
+        "names": [
+          "Launchpad",
+          "Standalone"
         ]
-    },
+      }
+    ],
     "midi": {
       "names":[
         "Launchpad Pro",

--- a/src/main/resources/hachi-pi.json
+++ b/src/main/resources/hachi-pi.json
@@ -2,12 +2,15 @@
   "filePrefix": "project1/",
   "midiContinueAsStart": true,
   "devices": {
-    "controller": {
-      "names": [
-        "Launchpad",
-        ",0,1"
+    "controllers": [
+      {
+        "type": "launchpadpro",
+        "names": [
+          "Launchpad",
+          ",0,1"
         ]
-    },
+      }
+    ],
     "midi": {
       "names":[
         "Launchpad Pro",


### PR DESCRIPTION
- Update clockable to follow every midi pulse instead of just 16th notes
- Update all clockable modules to use clock() call correctly
- Add swing offset to BeatModule to push/pull even 16th notes, set in settings, stored with session
- Add swing offset for ParaModule and StepModule, set in settings, but not saved
- No other modules have swing