### PR TITLE
Windows+printdevices

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -2,7 +2,7 @@
 
 These are instructions for setting up Issho on a portable, headless Raspberry Pi. The same 
 instructions will also work for a Mac or other Unix machine; just skip the steps about 
-booting the Pi directly into Hachi. Hachi should also run on Windows, but it's untested.
+booting the Pi directly into Hachi. Hachi should also run on Windows, but it's mostly untested.
 
 For these instructions, I'll assume basic familiarity with Unix and the ability to find and 
 install standard tools.
@@ -47,12 +47,19 @@ sequence data in the directory you run it from, so always run it from here.
 
 On a Pi, run it with this command:
 
-`> java -cp issho-1.0-shaded.jar net.perkowitz.issho.hachi.Hachi hachi-pi.json`
+`> java -cp issho-1.0.5-shaded.jar net.perkowitz.issho.hachi.Hachi hachi-pi.json`
 
 On a Mac:
 
-`> java -cp issho-1.0-shaded.jar net.perkowitz.issho.hachi.Hachi hachi-mac.json`
+`> java -cp issho-1.0-5-shaded.jar net.perkowitz.issho.hachi.Hachi hachi-mac.json`
 
+On Windows:
+* running the app
+
+`> java -cp issho-1.0.5-shaded.jar net.perkowitz.issho.hachi.Hachi <your-json-config>` 
+* listing available midi devices:
+
+`> java -cp issho-1.0.5-shaded.jar net.perkowitz.issho.util.FindMidiDevices` 
 
 # Set up the Pi
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.perkowitz</groupId>
     <artifactId>issho</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6-SNAPSHOT-s0len0id</version>
     <name>Issho</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.perkowitz</groupId>
     <artifactId>issho</artifactId>
-    <version>1.0.6-SNAPSHOT-s0len0id</version>
+    <version>1.0.6-SNAPSHOT</version>
     <name>Issho</name>
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/Hachi.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Hachi.java
@@ -231,7 +231,8 @@ public class Hachi {
             System.err.println("Unable to find config settings for midiInput device.");
         }
         if (midiInput == null) {
-            System.err.printf("Unable to find midi device matching name: %s\n", names);
+            System.err.printf("Unable to find midi-in device matching name: %s\n", names);
+            MidiUtil.printMidiDevices();
             System.exit(1);
         }
 
@@ -244,7 +245,8 @@ public class Hachi {
             System.err.println("Unable to find config settings for midiOutput device.");
         }
         if (midiOutput == null) {
-            System.err.printf("Unable to find midi device matching name: %s\n", names);
+            System.err.printf("Unable to find midi-out device matching name: %s\n", names);
+            MidiUtil.printMidiDevices();
             System.exit(1);
         }
 

--- a/src/main/java/net/perkowitz/issho/util/MidiUtil.java
+++ b/src/main/java/net/perkowitz/issho/util/MidiUtil.java
@@ -56,8 +56,10 @@ public class MidiUtil {
             midiDeviceInfos = MidiSystem.getMidiDeviceInfo();
         }
 
+        System.out.println("\nBelow midi device names are available in the OS; the .json config should reference these: ");
         for (int i = 0; i < midiDeviceInfos.length; i++) {
-            System.out.printf("Found midi device: %s, %s\n", midiDeviceInfos[i].getName(), midiDeviceInfos[i].getDescription());
+            System.out.printf("midi device name: \"%s\" (vendor=%s, descr=%s)\n",
+                    midiDeviceInfos[i].getName(), midiDeviceInfos[i].getVendor(),midiDeviceInfos[i].getDescription());
         }
     }
 


### PR DESCRIPTION
updates to:
* code: call printMidiDevices() when failing at startup + some printouts
* docs: added windows howto start-app + usage of FindMidiDevices.main()

* pom.xml: suggestion to use version 1.0.6-SNAPSHOT until next full version 1.0.6 release.

NOTE: i don't have a LaunchPadPro at hand to test with, shouldn't matter with these minor updates. Famous last words :)