### PR TITLE
Control resending of midi realtime messages

### DIFF
--- a/src/main/java/net/perkowitz/issho/hachi/Hachi.java
+++ b/src/main/java/net/perkowitz/issho/hachi/Hachi.java
@@ -82,6 +82,7 @@ public class Hachi {
      */
     public static void main(String args[]) throws Exception {
 
+//        Console.fg(Console.Color.GREEN, false);
         // settings
         String settingsFile = null;
         if (args.length > 0) {
@@ -126,6 +127,14 @@ public class Hachi {
         Boolean midiContinueAsStart = (Boolean)settings.get("midiContinueAsStart");
         if (midiContinueAsStart != null) {
             controller.setMidiContinueAsStart(midiContinueAsStart);
+        }
+        Boolean sendMidiRealtime = (Boolean)settings.get("sendMidiRealtime");
+        if (sendMidiRealtime != null) {
+            controller.setSendMidiRealtime(sendMidiRealtime);
+        }
+        Boolean debugMode = (Boolean)settings.get("debugMode");
+        if (debugMode != null) {
+            controller.setDebugMode(debugMode);
         }
 
         // if specified, create a knobby device and make the value control settings

--- a/src/main/java/net/perkowitz/issho/hachi/HachiController.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiController.java
@@ -22,7 +22,8 @@ import static javax.sound.midi.ShortMessage.*;
  */
 public class HachiController implements Clockable, Receiver, ValueSettable {
 
-    public static boolean DEBUG_MODE = false;
+    @Getter @Setter private static boolean debugMode = false;
+    @Setter private static boolean sendMidiRealtime = true;
 
     private static int STEP_MIN = 0;
     private static int STEP_MAX = 110;
@@ -69,6 +70,14 @@ public class HachiController implements Clockable, Receiver, ValueSettable {
 
         this.modules = modules;
         for (int i = 0; i < modules.length; i++) {
+//            GridColor color = Color.WHITE;
+//            if (modules[i] instanceof Multitrack) {
+//                Multitrack m = (Multitrack) modules[i];
+//                color = m.getEnabledColor();
+//            }
+//            Console.fg(Console.fromGrid((net.perkowitz.issho.devices.launchpadpro.Color)color), false);
+//            System.out.printf("Loading module: %s\n", modules[i].name());
+//            Console.reset();
             System.out.printf("Loading module: %s\n", modules[i]);
             if (modules[i] instanceof Clockable) {
                 clockables.add((Clockable)modules[i]);
@@ -274,7 +283,9 @@ public class HachiController implements Clockable, Receiver, ValueSettable {
 
             if (command == MIDI_REALTIME_COMMAND) {
                 // echo realtime commands to the midi output
-                outputReceiver.send(message, timeStamp);
+                if (sendMidiRealtime) {
+                    outputReceiver.send(message, timeStamp);
+                }
                 switch (status) {
                     case START:
 //                        System.out.println("START");

--- a/src/main/resources/hachi-dev.json
+++ b/src/main/resources/hachi-dev.json
@@ -1,6 +1,8 @@
 {
   "filePrefix": "project1/",
   "midiContinueAsStart": true,
+  "midiSendRealtime": false,
+  "debugMode": true,
   "devices": {
     "controllers": [
       {
@@ -40,6 +42,10 @@
     }
   },
   "modules": [
+    {
+      "class": "ShihaiModule",
+      "panicExclude": [14, 15]
+    },
     {
       "name": "G2 Drums",
       "class": "SeqModule",

--- a/src/main/resources/hachi-mac.json
+++ b/src/main/resources/hachi-mac.json
@@ -1,6 +1,8 @@
 {
   "filePrefix": "project1/",
   "midiContinueAsStart": true,
+  "midiSendRealtime": false,
+  "debugMode": false,
   "devices": {
     "controllers": [
       {

--- a/src/main/resources/hachi-pi.json
+++ b/src/main/resources/hachi-pi.json
@@ -1,6 +1,8 @@
 {
   "filePrefix": "project1/",
   "midiContinueAsStart": true,
+  "midiSendRealtime": true,
+  "debugMode": false,
   "devices": {
     "controllers": [
       {


### PR DESCRIPTION
The previous change to resend midi realtime messages when received doesn't work on OSX (because java support for those messages was never implemented) and generates errors when it runs. So now there is a flag in the settings json to decide whether or not to send those messages. It should be set to false when running on OSX.

Also added a flag for debug mode. The only effect at the moment is that, in debug mode, you can tap the exit button to quite, and in normal mode you have to hold it down for 2 seconds.