### PR TITLE
Optionally display a text map of hachi controls in the console.

### DIFF
--- a/doc/hachi/hachi.md
+++ b/doc/hachi/hachi.md
@@ -181,12 +181,21 @@ the data files.
 
 ```
   "midiContinueAsStart": true,
+  "midiSendRealtime": false,
+  "debugMode": true,
+  "textDisplay": false,
   "devices": {..},
   "modules": {..}
 ```
 
-Setting the midiContinueAsStart option to true will cause Hachi to restart on MIDI continue messages; when it is false, Hachi will continue
-running from the current step.
+Setting the `midiContinueAsStart` option to `true` will cause Hachi to restart on MIDI continue messages; when it is `false`, Hachi will continue
+running from the current step. When `midiSendRealtime` is `true`, Hachi will echo all MIDI realtime messages (clock, start/stop/continue, sysex)
+to its output; otherwise these messages will not be sent, and other MIDI devices cannot sync to Hachi. Note that MIDI realtime messages
+are not supported on Apple OSX, so this option should be `false` when running on a Mac. Enabling `debugMode` will allow you to exit Hachi
+by tapping the exit button and may display additional console output; when `debugMode` is `false`, the exit button must be held down for
+at least two seconds to exit. Setting `textDisplay` to `true` will display labels for Hachi's buttons and pads in the console. The labels
+will update when the active module changes. `textDisplay` uses ANSI escape sequences, so may not work in all clients. Set it to `false` to disable. 
+
 
 # Using Hachi
 

--- a/src/main/java/net/perkowitz/issho/hachi/HachiController.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiController.java
@@ -78,7 +78,7 @@ public class HachiController implements Clockable, Receiver, ValueSettable {
 //            Console.fg(Console.fromGrid((net.perkowitz.issho.devices.launchpadpro.Color)color), false);
 //            System.out.printf("Loading module: %s\n", modules[i].name());
 //            Console.reset();
-            System.out.printf("Loading module: %s\n", modules[i]);
+            System.out.printf("Loading module (%d): %s\n", i, modules[i].name());
             if (modules[i] instanceof Clockable) {
                 clockables.add((Clockable)modules[i]);
             }

--- a/src/main/java/net/perkowitz/issho/hachi/HachiController.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiController.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import net.perkowitz.issho.devices.*;
 import net.perkowitz.issho.hachi.modules.Module;
 import net.perkowitz.issho.hachi.modules.shihai.ShihaiModule;
+import net.perkowitz.issho.util.Terminal;
 
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.Receiver;
@@ -23,7 +24,7 @@ import static javax.sound.midi.ShortMessage.*;
 public class HachiController implements Clockable, Receiver, ValueSettable {
 
     @Getter @Setter private static boolean debugMode = false;
-    @Setter private static boolean sendMidiRealtime = true;
+    @Getter @Setter private static boolean sendMidiRealtime = false;
 
     private static int STEP_MIN = 0;
     private static int STEP_MAX = 110;
@@ -126,7 +127,6 @@ public class HachiController implements Clockable, Receiver, ValueSettable {
             hachiDeviceManager.selectModule(0);
         }
 
-        System.out.printf("Starting timer...\n");
         startTimer();
 
     }

--- a/src/main/java/net/perkowitz/issho/hachi/HachiDeviceManager.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiDeviceManager.java
@@ -3,6 +3,9 @@ package net.perkowitz.issho.hachi;
 import lombok.Getter;
 import net.perkowitz.issho.devices.*;
 import net.perkowitz.issho.hachi.modules.Module;
+import net.perkowitz.issho.hachi.modules.TextDisplay;
+import net.perkowitz.issho.hachi.modules.seq.SeqUtil;
+import net.perkowitz.issho.util.Terminal;
 
 import static net.perkowitz.issho.hachi.HachiUtil.*;
 
@@ -13,6 +16,7 @@ public class HachiDeviceManager implements GridListener {
 
     private Module[] modules = null;
     @Getter private Module activeModule;
+    private int activeModuleIndex = 0;
     private GridListener[] moduleListeners = null;
     private GridListener activeListener = null;
     private GridDisplay display;
@@ -32,6 +36,9 @@ public class HachiDeviceManager implements GridListener {
             moduleListeners[i] = modules[i].getGridListener();
             modules[i].setDisplay(hachiController.getDisplay(i));
         }
+        if (modules.length > activeModuleIndex) {
+            activeModule = modules[activeModuleIndex];
+        }
 
     }
 
@@ -50,12 +57,15 @@ public class HachiDeviceManager implements GridListener {
             }
 
             display = hachiController.getDisplay(index);
-            activeModule = modules[index];
+            activeModuleIndex = index;
+            activeModule = modules[activeModuleIndex];
             activeListener = moduleListeners[index];
             activeModule.redraw();
             redraw();
 
-            System.out.printf("\rActive module: %d:%s [%s]\n", index, activeModule.name(), activeModule.shortName());
+//            Terminal.go(TextDisplay.BOTTOM_ROW + 2, 1);
+//            System.out.printf("Active: %d:%s\n", index, activeModule.name());
+            TextDisplay.drawModules(modules, index);
         }
     }
 
@@ -85,6 +95,18 @@ public class HachiDeviceManager implements GridListener {
             display.setButton(EXIT_BUTTON, COLOR_UNSELECTED);
         }
 
+        textDraw();
+    }
+
+    public void textDraw() {
+        Terminal.fg(Terminal.Color.WHITE);
+        TextDisplay.clearFrame();
+        TextDisplay.drawModules(modules, activeModuleIndex);
+        TextDisplay.drawButtons(activeModule.buttonLabels());
+        TextDisplay.drawRows(activeModule.rowLabels());
+        TextDisplay.drawFrame();
+
+        Terminal.fg(Terminal.Color.GREEN);
     }
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/HachiDeviceManager.java
+++ b/src/main/java/net/perkowitz/issho/hachi/HachiDeviceManager.java
@@ -54,6 +54,8 @@ public class HachiDeviceManager implements GridListener {
             activeListener = moduleListeners[index];
             activeModule.redraw();
             redraw();
+
+            System.out.printf("\rActive module: %d:%s [%s]\n", index, activeModule.name(), activeModule.shortName());
         }
     }
 
@@ -79,7 +81,7 @@ public class HachiDeviceManager implements GridListener {
             display.setButton(PLAY_BUTTON, COLOR_UNSELECTED);
         }
 
-        if (HachiController.DEBUG_MODE) {
+        if (HachiController.isDebugMode()) {
             display.setButton(EXIT_BUTTON, COLOR_UNSELECTED);
         }
 
@@ -110,6 +112,7 @@ public class HachiDeviceManager implements GridListener {
             // top row used for module switching
             selectModule(button.getIndex());
 
+
         } else if (button.equals(PLAY_BUTTON)) {
             hachiController.pressPlay();
             redraw();
@@ -132,7 +135,7 @@ public class HachiDeviceManager implements GridListener {
             // top row used for module switching
         } else if (button.equals(PLAY_BUTTON)) {
         } else if (button.equals(EXIT_BUTTON)) {
-            if (elapsed > EXIT_PRESS_IN_MILLIS || HachiController.DEBUG_MODE) {
+            if (elapsed > EXIT_PRESS_IN_MILLIS || HachiController.isDebugMode()) {
                 hachiController.pressExit();
             }
         } else {

--- a/src/main/java/net/perkowitz/issho/hachi/modules/BasicModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/BasicModule.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.perkowitz.issho.devices.*;
 import net.perkowitz.issho.devices.launchpadpro.Color;
+import net.perkowitz.issho.util.DisplayUtil;
 
 /**
  * Created by optic on 9/12/16.
@@ -32,6 +33,19 @@ public class BasicModule implements Module, GridListener {
     public String shortName() {
         return "Bas";
     }
+
+    public DisplayUtil.Color color() {
+        return DisplayUtil.Color.WHITE;
+    }
+
+    public String[] buttonLabels() {
+        return new String[0];
+    }
+
+    public String[] rowLabels() {
+        return new String[0];
+    }
+
 
     /***** GridListener interface ****************************************/
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/BasicModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/BasicModule.java
@@ -25,6 +25,14 @@ public class BasicModule implements Module, GridListener {
 
     public void mute(boolean muted) {}
 
+    public String name() {
+        return "Basic";
+    }
+
+    public String shortName() {
+        return "Bas";
+    }
+
     /***** GridListener interface ****************************************/
 
     public void onPadPressed(GridPad pad, int velocity) {

--- a/src/main/java/net/perkowitz/issho/hachi/modules/Module.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/Module.java
@@ -12,5 +12,7 @@ public interface Module {
     public GridListener getGridListener();
     public void redraw();
     public void shutdown();
+    public String name();
+    public String shortName();
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/Module.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/Module.java
@@ -2,6 +2,7 @@ package net.perkowitz.issho.hachi.modules;
 
 import net.perkowitz.issho.devices.GridDisplay;
 import net.perkowitz.issho.devices.GridListener;
+import net.perkowitz.issho.util.DisplayUtil;
 
 /**
  * Created by optic on 9/12/16.
@@ -14,5 +15,8 @@ public interface Module {
     public void shutdown();
     public String name();
     public String shortName();
+    public DisplayUtil.Color color();
+    public String[] buttonLabels();
+    public String[] rowLabels();
 
 }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/TextDisplay.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/TextDisplay.java
@@ -1,0 +1,96 @@
+package net.perkowitz.issho.hachi.modules;
+
+import lombok.Setter;
+import net.perkowitz.issho.util.Terminal;
+import net.perkowitz.issho.util.Terminal.Color;
+import static net.perkowitz.issho.util.Terminal.Color.*;
+
+public class TextDisplay {
+
+    public static int TOP_ROW = 2;
+    public static int BOTTOM_ROW = 12;
+    public static int LEFT_COLUMN = 6;
+    public static int RIGHT_COLUMN = 46;
+    public static int COLUMN_WIDTH = 5;
+    public static int LOG_ROW = 16;
+
+    public static Color defaultColor = GREEN;
+
+    @Setter private static boolean enabled = false;
+
+    public static void clearFrame() {
+        if (!enabled) return;
+        for (int row = 1; row < LOG_ROW; row++) {
+            Terminal.clearRow(row);
+        }
+    }
+
+    public static void drawFrame() {
+        if (!enabled) return;
+        Terminal.fg(RED);
+        Terminal.go(TOP_ROW + 1, LEFT_COLUMN);
+        System.out.printf(" --------------------------------------- ");
+        Terminal.go(BOTTOM_ROW, LEFT_COLUMN);
+        System.out.printf(" --------------------------------------- ");
+        for (int i = 0; i < 8; i++) {
+            Terminal.go(TOP_ROW + i + 2, LEFT_COLUMN);
+            System.out.printf("|");
+            Terminal.go(TOP_ROW + i + 2, RIGHT_COLUMN);
+            System.out.printf("|");
+        }
+        Terminal.fg(defaultColor);
+    }
+
+    public static void drawModules(Module[] modules, int currentIndex) {
+        if (!enabled) return;
+        Terminal.fg(WHITE);
+        for (int i = 0; i < modules.length; i++) {
+            Terminal.go(TOP_ROW, LEFT_COLUMN + (i * COLUMN_WIDTH) + 1);
+            if (i == currentIndex) {
+                Terminal.invert();
+                System.out.printf("%s", modules[i].shortName());
+                Terminal.reset();
+            } else {
+                System.out.printf("%s", modules[i].shortName());
+            }
+        }
+        Terminal.fg(defaultColor);
+    }
+
+    // labels consists of 8 labels for left buttons, 8 for right, 8 for bottom
+    public static void drawButtons(String[] labels) {
+        if (!enabled) return;
+        if (labels.length < 24) {
+            return;
+        }
+
+        Terminal.fg(WHITE);
+        for (int i = 0; i < 8; i++) {
+            Terminal.go(TOP_ROW + i + 2, 1);
+            System.out.printf("%s", labels[i]);
+        }
+        for (int i = 8; i < 16; i++) {
+            Terminal.go(TOP_ROW + i - 6, RIGHT_COLUMN + 2);
+            System.out.printf("%s", labels[i]);
+        }
+        for (int i = 16; i < 24; i++) {
+            Terminal.go(BOTTOM_ROW + 1, LEFT_COLUMN + ((i - 16) * COLUMN_WIDTH) + 1);
+            System.out.printf("%s ", labels[i]);
+        }
+        Terminal.fg(defaultColor);
+    }
+
+    public static void drawRows(String[] labels) {
+        if (!enabled) return;
+        if (labels.length < 8) {
+            return;
+        }
+
+        Terminal.fg(WHITE);
+        for (int i = 0; i < 8; i++) {
+            Terminal.go(TOP_ROW + i + 2, LEFT_COLUMN + 4);
+            System.out.printf("%s ", labels[i]);
+        }
+        Terminal.fg(defaultColor);
+    }
+}

--- a/src/main/java/net/perkowitz/issho/hachi/modules/deprecated/rhythm/RhythmModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/deprecated/rhythm/RhythmModule.java
@@ -11,6 +11,7 @@ import net.perkowitz.issho.hachi.Sessionizeable;
 import net.perkowitz.issho.hachi.modules.Muteable;
 import net.perkowitz.issho.hachi.modules.deprecated.rhythm.models.*;
 import net.perkowitz.issho.hachi.modules.Module;
+import net.perkowitz.issho.util.DisplayUtil;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import javax.sound.midi.InvalidMidiDataException;
@@ -114,6 +115,19 @@ public class RhythmModule implements Module, RhythmInterface, Clockable, Session
     public String shortName() {
         return "Rhyt";
     }
+
+    public DisplayUtil.Color color() {
+        return DisplayUtil.Color.WHITE;
+    }
+
+    public String[] buttonLabels() {
+        return new String[0];
+    }
+
+    public String[] rowLabels() {
+        return new String[0];
+    }
+
 
     /***** RhythmModule interface *********************************************************************/
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/deprecated/rhythm/RhythmModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/deprecated/rhythm/RhythmModule.java
@@ -107,6 +107,14 @@ public class RhythmModule implements Module, RhythmInterface, Clockable, Session
     }
 
 
+    public String name() {
+        return "Rhythm";
+    }
+
+    public String shortName() {
+        return "Rhyt";
+    }
+
     /***** RhythmModule interface *********************************************************************/
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/example/ExampleModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/example/ExampleModule.java
@@ -47,6 +47,14 @@ public class ExampleModule extends MidiModule implements Module, Clockable, Grid
     }
 
 
+    public String name() {
+        return "Example";
+    }
+
+    public String shortName() {
+        return "Exmp";
+    }
+
     /***** private implementation ****************************************/
 
     /**
@@ -129,7 +137,7 @@ public class ExampleModule extends MidiModule implements Module, Clockable, Grid
     /**
      * receive a set of notes for adjusting/filtering the module's output 
      * 
-     * @param notes
+     * @param chord
      */
     public void setChord(Chord chord) {
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/para/ParaModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/para/ParaModule.java
@@ -72,6 +72,14 @@ public class ParaModule extends ChordModule implements Module, Clockable, GridLi
     }
 
 
+    public String name() {
+        return "Para";
+    }
+
+    public String shortName() {
+        return "Para";
+    }
+
     /***** private implementation ****************************************/
 
     private void advance(boolean andReset) {

--- a/src/main/java/net/perkowitz/issho/hachi/modules/seq/SeqModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/seq/SeqModule.java
@@ -91,6 +91,14 @@ public class SeqModule extends MidiModule implements Module, Clockable, GridList
         load(0);
     }
 
+    public String name() {
+        return "Seq" + mode.toString();
+    }
+
+    public String shortName() {
+        return mode.toString().substring(0,4);
+    }
+
 
     /***** private implementation ****************************************/
 
@@ -300,19 +308,31 @@ public class SeqModule extends MidiModule implements Module, Clockable, GridList
     /***** Multitrack implementation ************************************/
 
     public int trackCount() {
-        return SeqUtil.BEAT_TRACK_COUNT;
+        if (mode == BEAT) {
+            return SeqUtil.BEAT_TRACK_COUNT;
+        }
+        return 1;
     }
 
     public boolean getTrackEnabled(int index) {
+        if (index >= trackCount()) {
+            return false;
+        }
         return memory.getCurrentSession().getTracksEnabled().get(index);
     }
 
     public void setTrackEnabled(int index, boolean enabled) {
+        if (index >= trackCount()) {
+            return;
+        }
         memory.getCurrentSession().setTrackEnabled(index, enabled);
         seqDisplay.drawTracks(memory);
     }
 
     public void toggleTrackEnabled(int index) {
+        if (index >= trackCount()) {
+            return;
+        }
         memory.getCurrentSession().toggleTrackEnabled(index);
         seqDisplay.drawTracks(memory);
     }

--- a/src/main/java/net/perkowitz/issho/hachi/modules/seq/SeqModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/seq/SeqModule.java
@@ -13,6 +13,7 @@ import net.perkowitz.issho.hachi.Saveable;
 import net.perkowitz.issho.hachi.Sessionizeable;
 import net.perkowitz.issho.hachi.modules.*;
 import net.perkowitz.issho.hachi.modules.Module;
+import net.perkowitz.issho.util.DisplayUtil;
 import net.perkowitz.issho.util.MidiUtil;
 import org.codehaus.jackson.map.ObjectMapper;
 
@@ -97,6 +98,26 @@ public class SeqModule extends MidiModule implements Module, Clockable, GridList
 
     public String shortName() {
         return mode.toString().substring(0,4);
+    }
+
+    public String[] buttonLabels() {
+        switch (mode) {
+            case BEAT:
+                return BUTTON_LABELS_BEAT;
+            case MONO:
+                return BUTTON_LABELS_MONO;
+        }
+        return new String[0];
+    }
+
+    public String[] rowLabels() {
+        switch (mode) {
+            case BEAT:
+                return ROW_LABELS_BEAT;
+            case MONO:
+                return ROW_LABELS_MONO;
+        }
+        return new String[0];
     }
 
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/seq/SeqUtil.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/seq/SeqUtil.java
@@ -37,6 +37,31 @@ public class SeqUtil {
     public static int[] BEAT_TRACK_NOTES = new int[] { 49, 37, 39, 51, 42, 44, 46, 50,
             36, 38, 40, 41, 43, 45, 47, 48 };
 
+    /***** Labels for text output *****/
+    public static String[] ROW_LABELS_BEAT = new String[]{
+            "Pattern","",
+            "Track Mute","",
+            "Track Select","",
+            "Step","",
+    };
+    public static String[] ROW_LABELS_MONO = new String[]{
+            "Pattern","",
+            "Modifiers","Octave",
+            "Keyboard","",
+            "Step","",
+    };
+
+    // these should be <=4 chars
+    public static String[] BUTTON_LABELS_BEAT = new String[]{
+            "Play", "Exit", "Copy", "Slct", "Rand", "Save", "Sett", "Mute",
+            "-", "-", "-", "Valu", "-", "-", "-", "-",
+            "Gate", "Ctrl", "Ptch", "", "", "", "Jump", "Fill"
+    };
+    public static String[] BUTTON_LABELS_MONO = new String[]{
+            "Play", "Exit", "Copy", "Slct", "Rand", "Save", "Sett", "Mute",
+            "-", "-", "-", "Valu", "-", "-", "-", "-",
+            "Gate", "Ctrl", "Ptch", "Step", "", "", "Jump", "Fill"
+    };
 
     /***** controls *****************/
 

--- a/src/main/java/net/perkowitz/issho/hachi/modules/shihai/ShihaiModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/shihai/ShihaiModule.java
@@ -57,6 +57,14 @@ public class ShihaiModule extends MidiModule implements Clockable {
     }
 
 
+    public String name() {
+        return "Shihai";
+    }
+
+    public String shortName() {
+        return "Shih";
+    }
+
     public int tempo() {
         if (tempoIndex < tempos.length && tempoIndex >= 0) {
             return tempos[tempoIndex];
@@ -95,7 +103,6 @@ public class ShihaiModule extends MidiModule implements Clockable {
         this.shihaiDisplay.setDisplay(display);
         this.settingsModule.setDisplay(display);
     }
-
 
 
     /***** GridListener interface ****************************************/

--- a/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
+++ b/src/main/java/net/perkowitz/issho/hachi/modules/step/StepModule.java
@@ -64,6 +64,15 @@ public class StepModule extends ChordModule implements Module, Clockable, GridLi
     }
 
 
+    public String name() {
+        return "Step";
+    }
+
+    public String shortName() {
+        return "Step";
+    }
+
+
     /***** private implementation ****************************************/
 
     private void advance(boolean andReset) {

--- a/src/main/java/net/perkowitz/issho/util/DisplayUtil.java
+++ b/src/main/java/net/perkowitz/issho/util/DisplayUtil.java
@@ -1,0 +1,30 @@
+package net.perkowitz.issho.util;
+
+import static net.perkowitz.issho.util.DisplayUtil.Color.*;
+
+public class DisplayUtil {
+
+    // 2nd and 3rd rows should correspond: regular color/dim version, for ease of conversion; WHITE/GRAY should be start of lists
+    public enum Color {
+        BLACK,
+        WHITE, RED, ORANGE, YELLOW, GREEN, BLUEGREEN, BLUE, PURPLE, PINK,
+        GRAY, DIM_RED, DIM_ORANGE, DIM_YELLOW, DIM_GREEN, DIM_BLUEGREEN, DIM_BLUE, DIM_PURPLE, DIM_PINK
+    }
+
+    private static int WHITE_VALUE = WHITE.ordinal();
+    private static int GRAY_VALUE = GRAY.ordinal();
+
+    public static Color dim(Color color) {
+        if (color == BLACK) {
+            return BLACK;
+        }
+        if (color.ordinal() >= GRAY_VALUE) {
+            return color;
+        }
+
+        int v = color.ordinal() + (GRAY_VALUE - WHITE_VALUE);
+        return Color.values()[v];
+    }
+
+}
+

--- a/src/main/java/net/perkowitz/issho/util/Terminal.java
+++ b/src/main/java/net/perkowitz/issho/util/Terminal.java
@@ -1,0 +1,74 @@
+package net.perkowitz.issho.util;
+
+import com.google.common.collect.Maps;
+import net.perkowitz.issho.devices.launchpadpro.Color;
+import net.perkowitz.issho.devices.launchpadpro.LaunchpadPro;
+
+import java.util.Map;
+
+public class Terminal {
+
+    public enum Color {
+        BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE
+    }
+
+    private static int FOREGROUND_BASE = 30;
+    private static int BACKGROUND_BASE = 40;
+    private static String BRIGHT_SUFFIX = ";1";
+
+    public static void fg(Color color) {
+        fg(color, false);
+    }
+    public static void fg(Color color, boolean bright) {
+        String b = "";
+        if (bright) {
+            b = BRIGHT_SUFFIX;
+        }
+        System.out.printf("%c[%d%sm", 27, FOREGROUND_BASE + color.ordinal(), b);
+    }
+
+    public static void bg(Color color, boolean bright) {
+        String b = "";
+        if (bright) {
+            b = BRIGHT_SUFFIX;
+        }
+        System.out.printf("%c[%d%sm", 27, BACKGROUND_BASE + color.ordinal(), b);
+    }
+
+    public static void reset() {
+        System.out.printf("%c%s", 27, "[0m");
+    }
+
+    public static void go(int row, int column) {
+        System.out.printf("%c[%d;%dH", 27, row, column);
+    }
+
+    public static void go(int row, int column, String message) {
+        go(row, column);
+        System.out.printf(message);
+    }
+
+    public static void go(int row, int column, Color color, String message) {
+        go(row, column);
+        fg(color);
+        System.out.printf(message);
+    }
+
+    public static void invert() {
+        System.out.printf("%c[7m", 27);
+    }
+
+    public static void clear() {
+        System.out.printf("%c[%s", 27, "2J");
+        go(1, 1);
+    }
+
+    public static void clearRow(int row) {
+        go(row, 1);
+        System.out.printf("%c[0K", 27);
+    }
+
+    public static void beginLine() {
+        System.out.printf("%c[%nG", 27, 1);
+    }
+}

--- a/src/main/resources/hachi-dev.json
+++ b/src/main/resources/hachi-dev.json
@@ -3,6 +3,7 @@
   "midiContinueAsStart": true,
   "midiSendRealtime": false,
   "debugMode": true,
+  "textDisplay": false,
   "devices": {
     "controllers": [
       {


### PR DESCRIPTION
When the "textDisplay" option is set to true, Hachi will print a simple map of the Hachi controls in the console, with function labels for the buttons on each side and labels for the rows of pads.

Each module can provide its own labels, and the labels will be updated when changing modules. The top row also indicates the active module. Labels have only been defined for the Seq module so far.

The display uses ANSI escape sequences to arrange the labels, so may not work in all clients.